### PR TITLE
Allow binding Prometheus listener to specific address and port

### DIFF
--- a/README.turnserver
+++ b/README.turnserver
@@ -281,6 +281,10 @@ Flags:
 			check: across the session, all requests must have the same
 			main ORIGIN attribute value (if the ORIGIN was
 			initially used by the session).
+ --prometheus		Enable prometheus metrics. By default it is
+			disabled. Would listen on port 9641 unther the path /metrics
+			also the path / on this port can be used as a health check.
+			See also options --prometheus-ip and --prometheus-port.
 
 -h			Help.
 
@@ -392,13 +396,6 @@ Options with values:
 			will be employed (OS-dependent). In the older Linux systems
 			(before Linux kernel 3.9), the number of UDP threads is always one threads
 			per network listening endpoint - unless "-m 0" or "-m 1" is set.
-
---prometheus		Enable prometheus metrics. By default it is disabled. If no argument
-			is given, then it will listen on port 9641 on the wildcard address under
-			the path /metrics. An IP address may be specified to only bind to that
-			address, and in this case a port number may also be specified in order to
-			override the default port. The path / on this port can also be used as a
-			health check.
 
 --min-port		Lower bound of the UDP port range for relay
 			endpoints allocation.
@@ -586,6 +583,10 @@ Options with values:
 			If address family not requested explicitly by the client, then it falls back to this default.
 			The standard RFC explicitly define that this default must be IPv4, 
 			so use other option values with care!
+
+--prometheus-ip		IP address to bind the Prometheus listener to. Default is the wildcard address.
+
+--prometheus-port	Port to bind the Prometheus listener to. Default is 9641.
 
 --cli-ip		Local system IP address to be used for CLI management interface.
 			The turnserver process can be accessed for management with telnet,

--- a/README.turnserver
+++ b/README.turnserver
@@ -281,9 +281,6 @@ Flags:
 			check: across the session, all requests must have the same
 			main ORIGIN attribute value (if the ORIGIN was
 			initially used by the session).
- --prometheus		Enable prometheus metrics. By default it is
-			disabled. Would listen on port 9641 unther the path /metrics
-			also the path / on this port can be used as a health check
 
 -h			Help.
 
@@ -395,6 +392,13 @@ Options with values:
 			will be employed (OS-dependent). In the older Linux systems
 			(before Linux kernel 3.9), the number of UDP threads is always one threads
 			per network listening endpoint - unless "-m 0" or "-m 1" is set.
+
+--prometheus		Enable prometheus metrics. By default it is disabled. If no argument
+			is given, then it will listen on port 9641 on the wildcard address under
+			the path /metrics. An IP address may be specified to only bind to that
+			address, and in this case a port number may also be specified in order to
+			override the default port. The path / on this port can also be used as a
+			health check.
 
 --min-port		Lower bound of the UDP port range for relay
 			endpoints allocation.

--- a/docker/coturn/alpine/Dockerfile
+++ b/docker/coturn/alpine/Dockerfile
@@ -30,11 +30,11 @@ RUN apk add --no-cache \
         libmicrohttpd-dev
 
 # Prepare prometheus-client-c sources for building.
-ARG prom_ver=0.1.3
+ARG prom_commit=66deada5dc9b005ffd1bb509ff08b2d1d722356c
 RUN mkdir -p /build/ && cd /build/ \
  && git init \
- && git remote add origin https://github.com/digitalocean/prometheus-client-c \
- && git fetch --depth=1 origin "v${prom_ver}" \
+ && git remote add origin https://github.com/wireapp/prometheus-client-c \
+ && git fetch --depth=1 origin "${prom_commit}" \
  && git checkout FETCH_HEAD
 
 # Build libprom.so from sources.
@@ -48,13 +48,10 @@ RUN mkdir -p /build/prom/build/ && cd /build/prom/build/ \
 
 # Build libpromhttp.so from sources.
 RUN mkdir -p /build/promhttp/build/ && cd /build/promhttp/build/ \
- # Fix compiler warning: -Werror=incompatible-pointer-types
- && sed -i 's/\&promhttp_handler/(MHD_AccessHandlerCallback)\&promhttp_handler/' \
-           /build/promhttp/src/promhttp.c \
  && TEST=0 cmake -G "Unix Makefiles" \
                  -DCMAKE_INSTALL_PREFIX=/usr \
                  -DCMAKE_SKIP_BUILD_RPATH=TRUE \
-                 -DCMAKE_C_FLAGS="-g -O3" \
+                 -DCMAKE_C_FLAGS="-g -O2" \
                  .. \
  && make VERBOSE=1
 
@@ -120,7 +117,7 @@ WORKDIR /app/
 # Use Coturn sources from Git if `coturn_git_ref` is specified.
 ARG coturn_git_ref=HEAD
 ARG coturn_github_url=https://github.com
-ARG coturn_github_repo=coturn/coturn
+ARG coturn_github_repo=wir/coturn
 
 RUN if [ "${coturn_git_ref}" != 'HEAD' ]; then true \
  && rm -rf /app/* \

--- a/docker/coturn/alpine/Dockerfile
+++ b/docker/coturn/alpine/Dockerfile
@@ -117,7 +117,7 @@ WORKDIR /app/
 # Use Coturn sources from Git if `coturn_git_ref` is specified.
 ARG coturn_git_ref=HEAD
 ARG coturn_github_url=https://github.com
-ARG coturn_github_repo=wir/coturn
+ARG coturn_github_repo=wireapp/coturn
 
 RUN if [ "${coturn_git_ref}" != 'HEAD' ]; then true \
  && rm -rf /app/* \

--- a/docker/coturn/debian/Dockerfile
+++ b/docker/coturn/debian/Dockerfile
@@ -30,11 +30,11 @@ RUN apt-get install -y --no-install-recommends --no-install-suggests \
             libmicrohttpd-dev
 
 # Prepare prometheus-client-c sources for building.
-ARG prom_ver=0.1.3
+ARG prom_commit=66deada5dc9b005ffd1bb509ff08b2d1d722356c
 RUN mkdir -p /build/ && cd /build/ \
  && git init \
- && git remote add origin https://github.com/digitalocean/prometheus-client-c \
- && git fetch --depth=1 origin "v${prom_ver}" \
+ && git remote add origin https://github.com/wireapp/prometheus-client-c \
+ && git fetch --depth=1 origin "${prom_commit}" \
  && git checkout FETCH_HEAD
 
 # Build libprom.so from sources.
@@ -48,13 +48,10 @@ RUN mkdir -p /build/prom/build/ && cd /build/prom/build/ \
 
 # Build libpromhttp.so from sources.
 RUN mkdir -p /build/promhttp/build/ && cd /build/promhttp/build/ \
- # Fix compiler warning: -Werror=incompatible-pointer-types
- && sed -i 's/\&promhttp_handler/(MHD_AccessHandlerCallback)\&promhttp_handler/' \
-           /build/promhttp/src/promhttp.c \
  && TEST=0 cmake -G "Unix Makefiles" \
                  -DCMAKE_INSTALL_PREFIX=/usr \
                  -DCMAKE_SKIP_BUILD_RPATH=TRUE \
-                 -DCMAKE_C_FLAGS="-g -O3" \
+                 -DCMAKE_C_FLAGS="-g -O2" \
                  .. \
  && make VERBOSE=1
 
@@ -119,7 +116,7 @@ WORKDIR /app/
 # Use Coturn sources from Git if `coturn_git_ref` is specified.
 ARG coturn_git_ref=HEAD
 ARG coturn_github_url=https://github.com
-ARG coturn_github_repo=coturn/coturn
+ARG coturn_github_repo=wireapp/coturn
 
 RUN if [ "${coturn_git_ref}" != 'HEAD' ]; then true \
  && rm -rf /app/* \

--- a/man/man1/turnserver.1
+++ b/man/man1/turnserver.1
@@ -422,6 +422,15 @@ The flag that sets the origin consistency
 check: across the session, all requests must have the same
 main ORIGIN attribute value (if the ORIGIN was
 initially used by the session).
+.RS
+.TP
+.B
+\fB\-\-prometheus\fP
+Enable prometheus metrics. By default it is
+disabled. Would listen on port 9641 unther the path /metrics
+also the path / on this port can be used as a health check.
+See also \fIoptions\fP \fB\-\-prometheus\-ip\fP and \fB\-\-prometheus\-port\fP.
+.RE
 .TP
 .B
 \fB\-h\fP
@@ -571,15 +580,6 @@ still be a separate thread). If not set, then a default optimal algorithm
 will be employed (OS\-dependent). In the older Linux systems
 (before Linux kernel 3.9), the number of UDP threads is always one threads
 per network listening endpoint \- unless "\fB\-m\fP 0" or "\fB\-m\fP 1" is set.
-.TP
-.B
-\fB\-\-prometheus\fP
-Enable prometheus metrics. By default it is disabled. If no argument
-is given, then it will listen on port 9641 on the wildcard address under
-the path /metrics. An IP address may be specified to only bind to that
-address, and in this case a port number may also be specified in order to
-override the default port. The path / on this port can also be used as a
-health check.
 .TP
 .B
 \fB\-\-min\-port\fP
@@ -838,6 +838,14 @@ TURN server allocates address family according TURN client requested address fam
 If address family not requested explicitly by the client, then it falls back to this default.
 The standard RFC explicitly define that this default must be IPv4, 
 so use other option values with care!
+.TP
+.B
+\fB\-\-prometheus\-ip\fP
+IP address to bind the Prometheus listener to. Default is the wildcard address.
+.TP
+.B
+\fB\-\-prometheus\-port\fP
+Port to bind the Prometheus listener to. Default is 9641.
 .TP
 .B
 \fB\-\-cli\-ip\fP

--- a/man/man1/turnserver.1
+++ b/man/man1/turnserver.1
@@ -422,14 +422,6 @@ The flag that sets the origin consistency
 check: across the session, all requests must have the same
 main ORIGIN attribute value (if the ORIGIN was
 initially used by the session).
-.RS
-.TP
-.B
-\fB\-\-prometheus\fP
-Enable prometheus metrics. By default it is
-disabled. Would listen on port 9641 unther the path /metrics
-also the path / on this port can be used as a health check
-.RE
 .TP
 .B
 \fB\-h\fP
@@ -579,6 +571,15 @@ still be a separate thread). If not set, then a default optimal algorithm
 will be employed (OS\-dependent). In the older Linux systems
 (before Linux kernel 3.9), the number of UDP threads is always one threads
 per network listening endpoint \- unless "\fB\-m\fP 0" or "\fB\-m\fP 1" is set.
+.TP
+.B
+\fB\-\-prometheus\fP
+Enable prometheus metrics. By default it is disabled. If no argument
+is given, then it will listen on port 9641 on the wildcard address under
+the path /metrics. An IP address may be specified to only bind to that
+address, and in this case a port number may also be specified in order to
+override the default port. The path / on this port can also be used as a
+health check.
 .TP
 .B
 \fB\-\-min\-port\fP

--- a/src/apps/relay/mainrelay.c
+++ b/src/apps/relay/mainrelay.c
@@ -1539,18 +1539,18 @@ static void set_option(int c, char *value)
 #endif
 #if !defined(TURN_NO_PROMETHEUS)
 	case PROMETHEUS_OPT:
-		turn_params.prometheus = turn_params.prometheus == 0 ? 1 : turn_params.prometheus;
+		turn_params.prometheus = turn_params.prometheus == PROM_DISABLED ? PROM_ENABLED : turn_params.prometheus;
 		break;
 	case PROMETHEUS_IP_OPT:
 		if(make_ioa_addr((const uint8_t*)value,0,&prometheus_addr)<0) {
 			TURN_LOG_FUNC(TURN_LOG_LEVEL_ERROR,"Cannot parse Prometheus listener address: %s\n", value);
 		} else {
-			turn_params.prometheus = 2;
+			turn_params.prometheus = PROM_ENABLED_WITH_IP;
 		}
 		break;
 	case PROMETHEUS_PORT_OPT:
 		prometheus_port = atoi(value);
-		turn_params.prometheus = turn_params.prometheus == 0 ? 1 : turn_params.prometheus;
+		turn_params.prometheus = turn_params.prometheus == PROM_DISABLED ? PROM_ENABLED : turn_params.prometheus;
 		break;
 #endif
 	case AUTH_SECRET_OPT:

--- a/src/apps/relay/mainrelay.h
+++ b/src/apps/relay/mainrelay.h
@@ -319,7 +319,6 @@ typedef struct _turn_params_ {
   vint user_quota;
   #if !defined(TURN_NO_PROMETHEUS)
   int  prometheus;
-  ioa_addr prometheus_address;
   #endif
 
 

--- a/src/apps/relay/mainrelay.h
+++ b/src/apps/relay/mainrelay.h
@@ -319,6 +319,7 @@ typedef struct _turn_params_ {
   vint user_quota;
   #if !defined(TURN_NO_PROMETHEUS)
   int  prometheus;
+  ioa_addr prometheus_address;
   #endif
 
 

--- a/src/apps/relay/prom_server.c
+++ b/src/apps/relay/prom_server.c
@@ -28,7 +28,7 @@ prom_counter_t *turn_total_traffic_peer_sentb;
 
 
 int start_prometheus_server(void){
-  if (turn_params.prometheus == 0){
+  if (turn_params.prometheus == PROM_DISABLED){
     return 1;
   }
   prom_collector_registry_default_init();
@@ -65,9 +65,11 @@ int start_prometheus_server(void){
   int flags = MHD_USE_SELECT_INTERNALLY;
   void *arg;
 
-  if (turn_params.prometheus == 1) {
+  if (turn_params.prometheus == PROM_ENABLED) {
     daemon = promhttp_start_daemon(flags, prometheus_port, NULL, NULL);
   } else {
+    // turn_params.prometheus == PROM_ENABLED_WITH_IP
+
     addr_set_port(&prometheus_addr, prometheus_port);
 
     if (prometheus_addr.ss.sa_family == AF_INET6) {

--- a/src/apps/relay/prom_server.c
+++ b/src/apps/relay/prom_server.c
@@ -3,6 +3,8 @@
 #include "mainrelay.h"
 #include "prom_server.h"
 
+int prometheus_port = DEFAULT_PROM_SERVER_PORT;
+ioa_addr prometheus_addr;
 
 prom_counter_t *turn_traffic_rcvp;
 prom_counter_t *turn_traffic_rcvb;
@@ -60,19 +62,19 @@ int start_prometheus_server(void){
   promhttp_set_active_collector_registry(NULL);
 
   struct MHD_Daemon *daemon;
-  int flags;
+  int flags = MHD_USE_SELECT_INTERNALLY;
   void *arg;
 
-  flags = MHD_USE_SELECT_INTERNALLY;
-
   if (turn_params.prometheus == 1) {
-    daemon = promhttp_start_daemon(flags, DEFAULT_PROM_SERVER_PORT, NULL, NULL);
+    daemon = promhttp_start_daemon(flags, prometheus_port, NULL, NULL);
   } else {
-    if (turn_params.prometheus_address.ss.sa_family == AF_INET6) {
+    addr_set_port(&prometheus_addr, prometheus_port);
+
+    if (prometheus_addr.ss.sa_family == AF_INET6) {
       flags |= MHD_USE_IPv6;
-      arg = &turn_params.prometheus_address.s6;
+      arg = &prometheus_addr.s6;
     } else {
-      arg = &turn_params.prometheus_address.s4;
+      arg = &prometheus_addr.s4;
     }
 
     daemon = promhttp_start_daemon_with_options(flags, 0, NULL, NULL, MHD_OPTION_SOCK_ADDR, arg, MHD_OPTION_END);

--- a/src/apps/relay/prom_server.h
+++ b/src/apps/relay/prom_server.h
@@ -21,6 +21,8 @@ extern "C" {
 #endif /* __clplusplus */
 
 #define DEFAULT_PROM_SERVER_PORT (9641)
+extern int prometheus_port;
+extern ioa_addr prometheus_addr;
 
 extern prom_counter_t *turn_new_allocation;
 extern prom_counter_t *turn_refreshed_allocation;

--- a/src/apps/relay/prom_server.h
+++ b/src/apps/relay/prom_server.h
@@ -20,6 +20,10 @@ extern "C" {
 }
 #endif /* __clplusplus */
 
+#define PROM_DISABLED		0
+#define PROM_ENABLED		1
+#define PROM_ENABLED_WITH_IP	2
+
 #define DEFAULT_PROM_SERVER_PORT (9641)
 extern int prometheus_port;
 extern ioa_addr prometheus_addr;


### PR DESCRIPTION
This PR expands coturn's Prometheus functionality to allow the IP and port the metrics listener should bind to to be explicitly specified on the command line or in the configuration file. Prior to this change, the metrics listener was hardcoded to listen on port 9641 on the wildcard address. This means the metrics endpoint might be exposed to the public internet in some configurations, which is probably not wanted, and it may not be possible to use a firewall for enforcing network policy in every environment. The ability to bind the listener to a specific IP address and port affords some granularity in setting policy to the operator.

The Dockerfiles in the repo have also been updated to use Wire's fork of `prometheus-client-c`, as upstream does not provide an API for specifying a specific address to bind to at the time of writing, while our fork has a feature patch to add this functionality.