### PR TITLE
Add metrics for active allocations

### DIFF
--- a/src/apps/relay/ns_ioalib_engine_impl.c
+++ b/src/apps/relay/ns_ioalib_engine_impl.c
@@ -3722,6 +3722,12 @@ void turn_report_allocation_set(void *a, turn_time_t lifetime, int refresh)
 					send_message_to_redis(e->rch, "publish", key, "%s lifetime=%lu", status, (unsigned long)lifetime);
 				}
 #endif
+#if !defined(TURN_NO_PROMETHEUS)
+				{
+					if(!refresh)
+						prom_report_allocation_start();
+				}
+#endif
 			}
 		}
 	}
@@ -3777,6 +3783,8 @@ void turn_report_allocation_delete(void *a)
 						prom_set_finished_traffic(NULL, (const char*)ss->username, (unsigned long)(ss->t_received_packets), (unsigned long)(ss->t_received_bytes), (unsigned long)(ss->t_sent_packets), (unsigned long)(ss->t_sent_bytes), false);
 						prom_set_finished_traffic(NULL, (const char*)ss->username, (unsigned long)(ss->t_peer_received_packets), (unsigned long)(ss->t_peer_received_bytes), (unsigned long)(ss->t_peer_sent_packets), (unsigned long)(ss->t_peer_sent_bytes), true);
 					}
+
+					prom_report_allocation_finish();
 				}
 #endif
 			}

--- a/src/apps/relay/prom_server.c
+++ b/src/apps/relay/prom_server.c
@@ -89,7 +89,7 @@ int start_prometheus_server(void){
 }
 
 void prom_set_finished_traffic(const char* realm, const char* user, unsigned long rsvp, unsigned long rsvb, unsigned long sentp, unsigned long sentb, bool peer){
-  if (turn_params.prometheus == 1){
+  if (turn_params.prometheus > PROM_DISABLED){
 
     const char *label[] = {realm, user};
 

--- a/src/apps/relay/prom_server.c
+++ b/src/apps/relay/prom_server.c
@@ -26,6 +26,7 @@ prom_counter_t *turn_total_traffic_peer_rcvb;
 prom_counter_t *turn_total_traffic_peer_sentp;
 prom_counter_t *turn_total_traffic_peer_sentb;
 
+prom_gauge_t *turn_active_allocations;
 
 int start_prometheus_server(void){
   if (turn_params.prometheus == PROM_DISABLED){
@@ -58,6 +59,9 @@ int start_prometheus_server(void){
   turn_total_traffic_peer_rcvb = prom_collector_registry_must_register_metric(prom_counter_new("turn_total_traffic_peer_rcvb", "Represents total finished sessions peer received bytes", 0, NULL));
   turn_total_traffic_peer_sentp = prom_collector_registry_must_register_metric(prom_counter_new("turn_total_traffic_peer_sentp", "Represents total finished sessions peer sent packets", 0, NULL));
   turn_total_traffic_peer_sentb = prom_collector_registry_must_register_metric(prom_counter_new("turn_total_traffic_peer_sentb", "Represents total finished sessions peer sent bytes", 0, NULL));
+
+  // Create total active allocations gauge
+  turn_active_allocations = prom_collector_registry_must_register_metric(prom_gauge_new("turn_active_allocations", "Number of currently active allocations", 0, NULL));
 
   promhttp_set_active_collector_registry(NULL);
 
@@ -114,6 +118,18 @@ void prom_set_finished_traffic(const char* realm, const char* user, unsigned lon
       prom_counter_add(turn_total_traffic_sentp, sentp, NULL);
       prom_counter_add(turn_total_traffic_sentb, sentb, NULL);
     }
+  }
+}
+
+void prom_report_allocation_start(){
+  if (turn_params.prometheus > PROM_DISABLED){
+    prom_gauge_inc(turn_active_allocations, NULL);
+  }
+}
+
+void prom_report_allocation_finish(){
+  if (turn_params.prometheus > PROM_DISABLED){
+    prom_gauge_dec(turn_active_allocations, NULL);
   }
 }
 

--- a/src/apps/relay/prom_server.h
+++ b/src/apps/relay/prom_server.h
@@ -52,6 +52,8 @@ extern prom_counter_t *turn_total_traffic_peer_rcvb;
 extern prom_counter_t *turn_total_traffic_peer_sentp;
 extern prom_counter_t *turn_total_traffic_peer_sentb;
 
+extern prom_gauge_t *turn_active_allocations;
+
 #define TURN_ALLOC_STR_MAX_SIZE (20)
 
 #ifdef __cplusplus
@@ -62,6 +64,9 @@ extern "C" {
 int start_prometheus_server(void);
 
 void prom_set_finished_traffic(const char* realm, const char* user, unsigned long rsvp, unsigned long rsvb, unsigned long sentp, unsigned long sentb, bool peer);
+
+void prom_report_allocation_start(void);
+void prom_report_allocation_finish(void);
 
 #endif /* TURN_NO_PROMETHEUS */
 


### PR DESCRIPTION
This change introduces a new Prometheus metric which tracks the number of currently active allocations. This information was only recorded in the Redis "statsdb" until now, however exposing this information via Prometheus is far more useful in our environment. We need to track this state in running coturn instances when performing traffic draining, for non-disruptive restarts.