### PR TITLE
Add container with pre-stop hook script.

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -3,6 +3,7 @@
 !docker/coturn/alpine/
 !docker/coturn/debian/
 !docker/coturn/rootfs/
+!docker/coturn/wireapp/
 
 !cmake/
 !CMakeLists.txt

--- a/docker/coturn/wireapp/Dockerfile
+++ b/docker/coturn/wireapp/Dockerfile
@@ -1,3 +1,8 @@
+# This image derives from another coturn image, and adds a script which
+# polls the Prometheus metrics endpoint until there are no more active
+# allocations. This is intended to be used as a pre-stop hook to allow graceful
+# termination of the coturn process without disrupting active allocations.
+
 ARG coturn_image=coturn/coturn
 ARG coturn_tag=latest
 

--- a/docker/coturn/wireapp/Dockerfile
+++ b/docker/coturn/wireapp/Dockerfile
@@ -1,0 +1,15 @@
+ARG coturn_image=coturn/coturn
+ARG coturn_tag=latest
+
+FROM ${coturn_image}:${coturn_tag}
+
+USER root
+
+RUN apt-get update \
+  && apt-get install -y --no-install-recommends --no-install-suggests \
+    curl grep coreutils
+
+COPY docker/coturn/wireapp/pre-stop-hook.sh /usr/local/bin/pre-stop-hook
+RUN chmod +x /usr/local/bin/pre-stop-hook
+
+USER nobody:nogroup

--- a/docker/coturn/wireapp/pre-stop-hook.sh
+++ b/docker/coturn/wireapp/pre-stop-hook.sh
@@ -1,0 +1,23 @@
+#!/bin/sh
+
+# FUTUREWORK: this will break with IPv6. this should be fixed so it works with
+# IPv6.
+
+set -uo pipefail
+
+SLEEPTIME=60
+
+host="$1"
+port="$2"
+
+url="http://$host:$port/metrics"
+
+while true; do
+    allocs=$(curl -s "$url" | grep -E '^turn_active_allocations' | cut -d' ' -f2)
+    if [ "$?" != 0 ]; then exit 1; fi
+
+    if [ -z "$allocs" ]; then exit 0; fi
+    if [ "$allocs" = 0 ]; then exit 0; fi
+
+    sleep "$SLEEPTIME"
+done

--- a/docker/coturn/wireapp/pre-stop-hook.sh
+++ b/docker/coturn/wireapp/pre-stop-hook.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 # FUTUREWORK: this will break with IPv6. this should be fixed so it works with
 # IPv6.

--- a/docker/coturn/wireapp/pre-stop-hook.sh
+++ b/docker/coturn/wireapp/pre-stop-hook.sh
@@ -12,12 +12,24 @@ port="$2"
 
 url="http://$host:$port/metrics"
 
+echo "Polling coturn status on $url"
+
 while true; do
     allocs=$(curl -s "$url" | grep -E '^turn_active_allocations' | cut -d' ' -f2)
-    if [ "$?" != 0 ]; then exit 1; fi
+    if [ "$?" != 0 ]; then
+        echo "Could not retrieve metrics from coturn!"
+        exit 1
+    fi
 
-    if [ -z "$allocs" ]; then exit 0; fi
-    if [ "$allocs" = 0 ]; then exit 0; fi
+    if [ -z "$allocs" ]; then
+        echo "No more active allocations, exiting"
+        exit 0
+    fi
+    if [ "$allocs" = 0 ]; then
+        echo "No more active allocations, exiting"
+        exit 0
+    fi
 
+    echo "Active allocations remaining, sleeping for $SLEEPTIME seconds"
     sleep "$SLEEPTIME"
 done


### PR DESCRIPTION
We need to be able to detect traffic drain conditions when performing graceful restarts of coturn. This change adds a container image definition which derives from another Debian-based coturn image, and adds a script to the image which polls the metrics endpoint until the number of active allocations reaches zero.

TODO(sysvinit): test this image works correctly as a replacement for existing usages of our coturn image.