### PR TITLE
Invert username metrics handling options

### DIFF
--- a/README.turnserver
+++ b/README.turnserver
@@ -293,9 +293,9 @@ Flags:
 			disabled. Would listen on port 9641 unther the path /metrics
 			also the path / on this port can be used as a health check.
 			See also options --prometheus-ip and --prometheus-port.
- --prometheus-no-username-labels	Disable labeling prometheus traffic
+ --prometheus-username-labels	Enable labeling prometheus traffic
 			metrics with client usernames. Labeling with client usernames is
-			enabled by default, however this may cause memory leaks when using
+			disabled by default, beacuse this may cause memory leaks when using
 			authentication with ephemeral usernames (e.g. TURN REST API).
 
 -h			Help.

--- a/man/man1/turnserver.1
+++ b/man/man1/turnserver.1
@@ -442,10 +442,10 @@ also the path / on this port can be used as a health check.
 See also \fIoptions\fP \fB\-\-prometheus\-ip\fP and \fB\-\-prometheus\-port\fP.
 .TP
 .B
-\fB\-\-prometheus\-no\-username\-labels\fP
-Disable labeling prometheus traffic
+\fB\-\-prometheus\-username\-labels\fP
+Enable labeling prometheus traffic
 metrics with client usernames. Labeling with client usernames is
-enabled by default, however this may cause memory leaks when using
+disabled by default, beacuse this may cause memory leaks when using
 authentication with ephemeral usernames (e.g. TURN REST API).
 .RE
 .TP

--- a/src/apps/relay/mainrelay.c
+++ b/src/apps/relay/mainrelay.c
@@ -174,7 +174,7 @@ TURN_CREDENTIALS_NONE, /* ct */
 0, /* user_quota */
 #if !defined(TURN_NO_PROMETHEUS)
 0, /* prometheus disabled by default */
-1, /* prometheus username labelling enabled by default when prometheus is enabled */
+0, /* prometheus username labelling disabled by default when prometheus is enabled */
 #endif
 ///////////// Users DB //////////////
 { (TURN_USERDB_TYPE)0, {"\0"}, {0,NULL, {NULL,0}} },
@@ -564,9 +564,9 @@ static char Usage[] = "Usage: turnserver [options]\n"
 " --prometheus					Enable prometheus metrics. It is disabled by default.\n"
 "						When enabled, it will listen on port 9641 on the wildcard address under the path /metrics.\n"
 "						The path / on this port can also be used as a health check.\n"
-" --prometheus-no-username-labels		When metrics are enabled, do not label metrics with client usernames.\n"
 " --prometheus-ip=<ip>				IP address for the Prometheus listener. Default is the wildcard address.\n"
 " --prometheus-port=<port>			Prometheus listener port. Default is 9641.\n"
+" --prometheus-username-labels			When metrics are enabled, add labels with client usernames.\n"
 #endif
 " --use-auth-secret				TURN REST API flag.\n"
 "						Flag that sets a special authorization option that is based upon authentication secret\n"
@@ -797,9 +797,9 @@ enum EXTRA_OPTS {
 	CHANNEL_LIFETIME_OPT,
 	PERMISSION_LIFETIME_OPT,
 	PROMETHEUS_OPT,
-	PROMETHEUS_DISABLE_USERNAMES_OPT,
 	PROMETHEUS_IP_OPT,
 	PROMETHEUS_PORT_OPT,
+	PROMETHEUS_ENABLE_USERNAMES_OPT,
 	AUTH_SECRET_OPT,
 	NO_AUTH_PINGS_OPT,
 	NO_DYNAMIC_IP_LIST_OPT,
@@ -916,9 +916,9 @@ static const struct myoption long_options[] = {
 #endif
 #if !defined(TURN_NO_PROMETHEUS)
 				{ "prometheus", optional_argument, NULL, PROMETHEUS_OPT },
-				{ "prometheus-no-username-labels", optional_argument, NULL, PROMETHEUS_DISABLE_USERNAMES_OPT },
 				{ "prometheus-ip", required_argument, NULL, PROMETHEUS_IP_OPT },
 				{ "prometheus-port", required_argument, NULL, PROMETHEUS_PORT_OPT },
+				{ "prometheus-username-labels", optional_argument, NULL, PROMETHEUS_ENABLE_USERNAMES_OPT },
 #endif
 				{ "use-auth-secret", optional_argument, NULL, AUTH_SECRET_OPT },
 				{ "static-auth-secret", required_argument, NULL, STATIC_AUTH_SECRET_VAL_OPT },
@@ -1552,8 +1552,8 @@ static void set_option(int c, char *value)
 	case PROMETHEUS_OPT:
 		turn_params.prometheus = turn_params.prometheus == PROM_DISABLED ? PROM_ENABLED : turn_params.prometheus;
 		break;
-	case PROMETHEUS_DISABLE_USERNAMES_OPT:
-		turn_params.prometheus_username_labels = 0;
+	case PROMETHEUS_ENABLE_USERNAMES_OPT:
+		turn_params.prometheus_username_labels = 1;
 		break;
 	case PROMETHEUS_IP_OPT:
 		if(make_ioa_addr((const uint8_t*)value,0,&prometheus_addr)<0) {


### PR DESCRIPTION
This is a backport of changes submitted upstream in coturn#919, which inverts the logic of the options for controlling username labeling on Prometheus metrics.