### PR TITLE
Fixup pre-stop-hook that is currently not working.

### DIFF
--- a/docker/coturn/wireapp/pre-stop-hook.sh
+++ b/docker/coturn/wireapp/pre-stop-hook.sh
@@ -25,7 +25,16 @@ while true; do
         echo "No more active allocations, exiting"
         exit 0
     fi
-    if [ "$allocs" = 0 ]; then
+
+    # Note: there can be multiple allocation counts, e.g.
+    # turn_total_allocations{type="UDP"} 0
+    # turn_total_allocations{type="TCP"} 0
+    # So we need to sum the counts before comparing with 0.
+    sum=0
+    for num in $allocs; do
+        (( sum += num ))
+    done
+    if [ "$sum" = 0 ]; then
         echo "No more active allocations, exiting"
         exit 0
     fi


### PR DESCRIPTION
For metrics looking like

```
curl -s http://192.168.0.9:9641/metrics | grep allocations
# HELP turn_total_allocations Represents current allocations number
# TYPE turn_total_allocations gauge
turn_total_allocations{type="UDP"} 0
turn_total_allocations{type="TCP"} 0
```
the script grepped for these lines and assigned `allocs="0 0"`, which is not empty, and it's not 0, and thus this pre stop hook keeps looping forever. 🙄 

This PR should fix that problem.

Part of https://wearezeta.atlassian.net/browse/WPB-5328