### PR TITLE
fix(actions): prevent command injection in docker release (WPB-9709)

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -172,10 +172,12 @@ jobs:
         if: ${{ startsWith(github.ref, 'refs/tags/') }}
       - name: Form main Docker image tag
         id: docker
-        run: echo "tag=${{ (startsWith(github.ref, 'refs/tags/')
-                            && steps.semver.outputs.group1)
-                        ||     'edge' }}-${{ matrix.dist }}"
+        run: echo "tag=${SEMVER}-${{ matrix.dist }}"
              >> $GITHUB_OUTPUT
+        env:
+          SEMVER: ${{ (startsWith(github.ref, 'refs/tags/')
+                      && steps.semver.outputs.group1)
+                      ||     'edge' }}
 
       - uses: actions/download-artifact@v4
         with:
@@ -276,9 +278,11 @@ jobs:
 
       - name: Parse CHANGELOG link
         id: changelog
-        run: echo "link=${{ github.server_url }}/${{ github.repository }}/blob/docker/${{ steps.semver.outputs.group1 }}/docker/coturn/CHANGELOG.md#$(sed -n '/^## \[${{ steps.semver.outputs.group1 }}\]/{s/^## \[\(.*\)\][^0-9]*\([0-9].*\)/\1--\2/;s/[^0-9a-z-]*//g;p;}' CHANGELOG.md)"
+        run: echo "link=${{ github.server_url }}/${{ github.repository }}/blob/docker/${SEMVER}/docker/coturn/CHANGELOG.md#$(sed -n '/^## \['${SEMVER}'\]/{s/^## \[\(.*\)\][^0-9]*\([0-9].*\)/\1--\2/;s/[^0-9a-z-]*//g;p;}' CHANGELOG.md)"
              >> $GITHUB_OUTPUT
         working-directory: docker/coturn/
+        env:
+          SEMVER: ${{ steps.semver.outputs.group1 }}
 
       - name: Create GitHub release
         uses: softprops/action-gh-release@v2


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

It was possible to run arbitrary commands in the context of the GitHub Actions workflow by pushing specially crafted tags, e.g. `git tag 'docker/0.0.0-1;$(cat${IFS}/etc/passwd)#'`. 
In this example, the workflow would run the `cat` command and print the contents of `/etc/passwd`.

### Causes

A portion of the git tag was extracted using a regex and used in a `run` step without sanitizing.

### Solutions

The extracted tag portion was first assigned to a shell variable and then used in a `run` step.

### Testing

#### How to Test

This change was tested with the workflow listed below in a separate repository by pushing tags in the shape of `'docker/0.0.0-1;$(cat${IFS}/etc/passwd)#'`.

`Test0` resembles the original workflow of this repo, and `Test1` is the fixed version.
`Test2` was provided to prove that one really needs to use the environment variable with bash variable substitution syntax, as GitHub Actions env substitution it using `${{ env ... }}` is still going to cause issues.

An actual test can be made by pushing above tag to this repo.

```yaml
# Example workflow crafted to prove command injection through a crafted semver tag
on:
  push: {}
jobs:
  publish_all:
    runs-on: ubuntu-latest
    steps:
      - name: Checkout
        uses: actions/checkout@v4.1.6
        with:
          fetch-depth: 0
      - name: Parse semver versions from Git tag
        id: semver
        uses: actions-ecosystem/action-regex-match@v2
        with:
          text: ${{ github.ref }}
          regex: '^refs/tags/docker/(((([0-9]+)\.[0-9]+)\.[0-9]+)-(.+))$'
        if: ${{ startsWith(github.ref, 'refs/tags/') }}
      - name: Test0 
        run: echo "tag=${{ (startsWith(github.ref, 'refs/tags/')
                   && steps.semver.outputs.group1)
                   || 'edge' }}-${{ matrix.dist }}"
      - name: Test1 
        run: echo "tag=${TAG}-${{ matrix.dist }}"
        env:
          TAG: ${{ (startsWith(github.ref, 'refs/tags/')
                   && steps.semver.outputs.group1)
                   || 'edge' }}
      - name: Test2 
        run: echo "tag=${{ env.TAG }}-${{ matrix.dist }}"
        env:
          TAG: ${{ (startsWith(github.ref, 'refs/tags/')
                   && steps.semver.outputs.group1)
                   || 'edge' }}
```


### Notes

Exploiting this requires knowledge of the workflow code, execution environment and, most importantly, tag push permission.

Note that git tags are quite restrictive in terms of which characters are allowed, so one cannot just paste a shell script, and that the tag push permission would usually imply that an attacker would already be able to directly modify workflow code.

Nevertheless, as a best practice, we shall try to sanitize any user input that is used in a `run` step.

**As this repo is a fork, we should consider upstreaming this change.**

----
#### PR Post Submission Checklist for internal contributors

 - [x] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
- https://wearezeta.atlassian.net/wiki/spaces/SC/pages/1216053328/How+to+avoid+Command+Injection+via+Github+Actions+or+CI+jobs+in+general
- https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#example-of-a-script-injection-attack
- related to [WPB-9709](https://wearezeta.atlassian.net/browse/WPB-9709)

[WPB-9577]: https://wearezeta.atlassian.net/browse/WPB-9577?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[WPB-9709]: https://wearezeta.atlassian.net/browse/WPB-9709?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ