### PR TITLE
Make use of drain in preStop hook script

### DIFF
--- a/docker/coturn/debian/Dockerfile
+++ b/docker/coturn/debian/Dockerfile
@@ -214,6 +214,7 @@ EXPOSE 3478 3478/udp 5349 5349/udp
 
 VOLUME ["/var/lib/coturn"]
 
-ENTRYPOINT ["/usr/bin/dumb-init", "--", "docker-entrypoint.sh"]
+# ENTRYPOINT ["/usr/bin/dumb-init", "--", "docker-entrypoint.sh"]
+ENTRYPOINT ["docker-entrypoint.sh"]
 
 CMD ["--log-file=stdout", "--external-ip=$(detect-external-ip)"]

--- a/docker/coturn/debian/Dockerfile
+++ b/docker/coturn/debian/Dockerfile
@@ -214,7 +214,6 @@ EXPOSE 3478 3478/udp 5349 5349/udp
 
 VOLUME ["/var/lib/coturn"]
 
-# ENTRYPOINT ["/usr/bin/dumb-init", "--", "docker-entrypoint.sh"]
 ENTRYPOINT ["docker-entrypoint.sh"]
 
 CMD ["--log-file=stdout", "--external-ip=$(detect-external-ip)"]

--- a/docker/coturn/debian/Dockerfile
+++ b/docker/coturn/debian/Dockerfile
@@ -188,6 +188,9 @@ RUN apt-get update \
  # Install `dig` tool for `detect-external-ip.sh`.
  && apt-get install -y --no-install-recommends --no-install-suggests \
             dnsutils \
+ # Install `dumb-init` to handle signaling (which we use for drain mode) correctly.
+ && apt-get install -y --no-install-recommends --no-install-suggests \
+            dumb-init \
  # Cleanup unnecessary stuff.
  && rm -rf /var/lib/apt/lists/*
 
@@ -211,6 +214,6 @@ EXPOSE 3478 3478/udp 5349 5349/udp
 
 VOLUME ["/var/lib/coturn"]
 
-ENTRYPOINT ["docker-entrypoint.sh"]
+ENTRYPOINT ["/usr/bin/dumb-init", "--", "docker-entrypoint.sh"]
 
 CMD ["--log-file=stdout", "--external-ip=$(detect-external-ip)"]

--- a/docker/coturn/wireapp/Dockerfile
+++ b/docker/coturn/wireapp/Dockerfile
@@ -12,7 +12,7 @@ USER root
 
 RUN apt-get update \
   && apt-get install -y --no-install-recommends --no-install-suggests \
-    curl grep coreutils
+    curl grep coreutils procps
 
 COPY docker/coturn/wireapp/pre-stop-hook.sh /usr/local/bin/pre-stop-hook
 RUN chmod +x /usr/local/bin/pre-stop-hook

--- a/docker/coturn/wireapp/pre-stop-hook.sh
+++ b/docker/coturn/wireapp/pre-stop-hook.sh
@@ -17,41 +17,39 @@ coturn_pid=$(pgrep -f "$coturn_exe" | head -n 1)
 
 function log(){
     msg=$1
+    # send log output of the preStop hook to stdout of
+    # the main turnserver process, so they show up in the
+    # normal logs of the pod.
     echo "PRESTOP: $msg" > "/proc/$coturn_pid/fd/1"
 }
 
-log "Polling coturn status on $url"
+function getAllocations(){
+    log "Polling coturn status on $url ..."
+    allocs=$(curl -s "$url" | grep -E '^turn_total_allocations' | cut -d' ' -f2)
+    if [ -z "$allocs" ]; then
+        # nobody used the coturn server yet, which means the metric is absent from the output, in which case default to 0.
+        allocs=0
+    fi
+    # Note: there can be multiple allocation counts, e.g.
+    # turn_total_allocations{type="UDP"} 0
+    # turn_total_allocations{type="TCP"} 0
+    # So we need to sum the counts before comparing with 0.
+    sum=0
+    for num in $allocs; do
+        (( sum += num ))
+    done
+    log "Active remaining turn_allocations: $sum"
+}
 
-allocs=$(curl -s "$url" | grep -E '^turn_total_allocations' | cut -d' ' -f2)
-if [ -z "$allocs" ]; then
-    # nobody used the coturn server yet, which means the metric is absent, default to 0.
-    allocs=0
-fi
-# Note: there can be multiple allocation counts, e.g.
-# turn_total_allocations{type="UDP"} 0
-# turn_total_allocations{type="TCP"} 0
-# So we need to sum the counts before comparing with 0.
-sum=0
-for num in $allocs; do
-    (( sum += num ))
-done
-
-log "Active allocations: [$sum] remaining."
+getAllocations
 
 # Invoke drain mode (https://github.com/wireapp/coturn/pull/12)
 log "Sending signal to drain coturn..."
 pkill -f --signal SIGUSR1 "$coturn_exe"
 
-sleep 1
-allocs=$(curl -s "$url" | grep -E '^turn_total_allocations' | cut -d' ' -f2)
-if [ -z "$allocs" ]; then
-    # nobody used the coturn server yet, which means the metric is absent, default to 0.
-    allocs=0
-fi
-log "After drain signal allocs: $allocs"
-
 while pgrep -f "$coturn_exe" > /dev/null; do
-    log "$coturn_exe is still running. Waiting..."
+    log "$coturn_exe is still running. Checking allocations then sleeping..."
+    getAllocations
     sleep $SLEEPTIME
 done
 log "$coturn_exe seems to have finished draining. Exiting."

--- a/docker/coturn/wireapp/pre-stop-hook.sh
+++ b/docker/coturn/wireapp/pre-stop-hook.sh
@@ -12,6 +12,9 @@ port="$2"
 
 url="http://$host:$port/metrics"
 
+# Invoke drain mode (https://github.com/wireapp/coturn/pull/12)
+pkill --signal SIGUSR1 turnserver
+
 echo "Polling coturn status on $url"
 
 while true; do

--- a/docker/coturn/wireapp/pre-stop-hook.sh
+++ b/docker/coturn/wireapp/pre-stop-hook.sh
@@ -24,7 +24,6 @@ function log(){
 }
 
 function getAllocations(){
-    log "Polling coturn status on $url ..."
     allocs=$(curl -s "$url" | grep -E '^turn_total_allocations' | cut -d' ' -f2)
     if [ -z "$allocs" ]; then
         # nobody used the coturn server yet, which means the metric is absent from the output, in which case default to 0.
@@ -41,6 +40,7 @@ function getAllocations(){
     log "Active remaining turn_allocations: $sum"
 }
 
+log "Polling coturn status on $url ..."
 getAllocations
 
 # Invoke drain mode (https://github.com/wireapp/coturn/pull/12)

--- a/docker/coturn/wireapp/pre-stop-hook.sh
+++ b/docker/coturn/wireapp/pre-stop-hook.sh
@@ -13,7 +13,7 @@ port="$2"
 url="http://$host:$port/metrics"
 
 coturn_exe=/usr/bin/turnserver
-coturn_pid=$(pgrep "$coturn_exe" | head -n 1)
+coturn_pid=$(pgrep -f "$coturn_exe" | head -n 1)
 
 function log(){
     msg=$1
@@ -50,7 +50,7 @@ log "Active allocations: [$sum] remaining."
 
 # Invoke drain mode (https://github.com/wireapp/coturn/pull/12)
 log "Sending signal to drain coturn..."
-pkill --signal SIGUSR1 "$coturn_exe"
+pkill -f --signal SIGUSR1 "$coturn_exe"
 
 sleep 1
 allocs2=$(curl -s "$url" | grep -E '^turn_total_allocations' | cut -d' ' -f2)
@@ -61,7 +61,7 @@ else
     log "$allocs2"
 fi
 
-while pgrep "$coturn_exe" > /dev/null; do
+while pgrep -f "$coturn_exe" > /dev/null; do
     log "$coturn_exe is still running. Waiting..."
     sleep $SLEEPTIME
 done

--- a/docker/coturn/wireapp/pre-stop-hook.sh
+++ b/docker/coturn/wireapp/pre-stop-hook.sh
@@ -13,7 +13,7 @@ port="$2"
 url="http://$host:$port/metrics"
 
 coturn_exe=/usr/bin/turnserver
-coturn_pid=$(pgrep -f "$coturn_exe" | head -n 1)
+coturn_pid=$(pgrep "$coturn_exe" | head -n 1)
 
 function log(){
     msg=$1
@@ -50,7 +50,7 @@ log "Active allocations: [$sum] remaining."
 
 # Invoke drain mode (https://github.com/wireapp/coturn/pull/12)
 log "Sending signal to drain coturn..."
-pkill -f --signal SIGUSR1 "$coturn_exe"
+pkill --signal SIGUSR1 "$coturn_exe"
 
 sleep 1
 allocs2=$(curl -s "$url" | grep -E '^turn_total_allocations' | cut -d' ' -f2)
@@ -61,7 +61,7 @@ else
     log "$allocs2"
 fi
 
-while pgrep -f "$coturn_exe" > /dev/null; do
+while pgrep "$coturn_exe" > /dev/null; do
     log "$coturn_exe is still running. Waiting..."
     sleep $SLEEPTIME
 done

--- a/docker/coturn/wireapp/pre-stop-hook.sh
+++ b/docker/coturn/wireapp/pre-stop-hook.sh
@@ -12,7 +12,8 @@ port="$2"
 
 url="http://$host:$port/metrics"
 
-coturn_pid=$(pgrep -f turnserver | head -n 1)
+coturn_exe=/usr/bin/turnserver
+coturn_pid=$(pgrep -f "$coturn_exe" | head -n 1)
 
 function log(){
     msg=$1
@@ -22,7 +23,7 @@ function log(){
 log "Sending signal to drain coturn"
 
 # Invoke drain mode (https://github.com/wireapp/coturn/pull/12)
-pkill -f --signal SIGUSR1 turnserver
+pkill -f --signal SIGUSR1 "$coturn_exe"
 
 log "Polling coturn status on $url"
 

--- a/docker/coturn/wireapp/pre-stop-hook.sh
+++ b/docker/coturn/wireapp/pre-stop-hook.sh
@@ -40,17 +40,14 @@ function getAllocations(){
     log "Active remaining turn_allocations: $sum"
 }
 
-log "Polling coturn status on $url ..."
 getAllocations
 
 # Invoke drain mode (https://github.com/wireapp/coturn/pull/12)
-log "Sending signal to drain coturn..."
 pkill -f --signal SIGUSR1 "$coturn_exe"
+log "Sent SIGUSR1 to $coturn_exe to start draining."
 
 while pgrep -f "$coturn_exe" > /dev/null; do
-    log "$coturn_exe is still running. Checking allocations then sleeping..."
+    log "$coturn_exe is still running"
     getAllocations
     sleep $SLEEPTIME
 done
-log "$coturn_exe seems to have finished draining. Exiting."
-exit 0


### PR DESCRIPTION
Changes:

* change the preStop hook to make use of the new drain functionality developed in #12
* add pgrep/pkill to the image used by the prestop hook
* output the logs of the prestop hook to stdout of the main coturn process, so that it's easier to see what happens when terminating a coturn pod.
* add dumb-init for improved signal handling in case of force killing pods.

