### PR TITLE
Migrate coturn chart from wire-server

### DIFF
--- a/charts/coturn/Chart.yaml
+++ b/charts/coturn/Chart.yaml
@@ -1,0 +1,14 @@
+apiVersion: v2
+name: coturn
+description: coturn - a STUN and TURN server
+type: application
+
+# This is the chart version. This version number should be incremented each time you make changes
+# to the chart and its templates, including the app version.
+# Versions are expected to follow Semantic Versioning (https://semver.org/)
+version: 0.0.42
+
+# This is the version number of the application being deployed. This version number should be
+# incremented each time you make changes to the application. Versions are not expected to
+# follow Semantic Versioning. They should reflect the version the application is using.
+appVersion: 4.6.2-federation-wireapp.16

--- a/charts/coturn/README.md
+++ b/charts/coturn/README.md
@@ -1,0 +1,25 @@
+**Warning**: this chart is currently considered beta. Use at your own risk!
+
+This chart deploys Wire's fork of [coturn](https://github.com/coturn/coturn),
+a STUN and TURN server, with some additional features developed by Wire (see
+[here](https://github.com/wireapp/coturn/tree/wireapp)) to support our calling
+services.
+
+You need to supply a list of one or more zrest secrets at the key
+`secrets.zrestSecrets`. The secret provided to the brig chart in
+`secrets.turn.secret` must be included in this list.
+
+Note that coturn pods are deployed with `hostNetwork: true`, as they need to
+listen on a wide range of UDP ports. Additionally, some TCP ports need to be
+exposed on the hosting node, which are listed in `values.yaml`.
+
+Due to the nature of TURN, this service might also expose the
+internal network to which the hosting node is connected. It is
+therefore recommended to run coturn on a separate Kubernetes cluster
+from the rest of the Wire services. Further details may be found in
+Wire's documentation for Restund, another TURN implementation, on
+[this](https://docs.wire.com/understand/restund.html#network) page.
+
+coturn can optionally be configured to expose a TLS control port. The TLS
+private key and certificates should be provided in a `Secret` whose name is
+given in `tls.secretRef`.

--- a/charts/coturn/templates/_helpers.tpl
+++ b/charts/coturn/templates/_helpers.tpl
@@ -1,0 +1,54 @@
+{{- define "coturn.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "coturn.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "coturn.labels" -}}
+helm.sh/chart: {{ include "coturn.chart" . }}
+{{ include "coturn.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Values.image.tag | default .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "coturn.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{- define "coturn.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "coturn.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/* Allow KubeVersion to be overridden. */}}
+{{- define "kubeVersion" -}}
+  {{- default .Capabilities.KubeVersion.Version .Values.kubeVersionOverride -}}
+{{- end -}}
+
+{{- define "includeSecurityContext" -}}
+  {{- (semverCompare ">= 1.24-0" (include "kubeVersion" .)) -}}
+{{- end -}}

--- a/charts/coturn/templates/configmap-coturn-conf-template.yaml
+++ b/charts/coturn/templates/configmap-coturn-conf-template.yaml
@@ -1,0 +1,112 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: coturn
+
+data:
+  coturn.conf.template: |
+    ## disable dtls control plane; don't permit relaying tcp connections.
+    no-dtls
+    no-tcp-relay
+
+    ## tls handling
+    {{- if .Values.tls.enabled }}
+    cert=/secrets-tls/tls.crt
+    pkey=/secrets-tls/tls.key
+    {{- if .Values.tls.ciphers }}
+    cipher-list={{ .Values.tls.ciphers }}
+    {{- end }}
+    {{- else }}
+    no-tls
+    {{- end }}
+
+    # This is mandatory for federated DTLS
+    CA-file=/etc/ssl/certs/ca-certificates.crt
+
+    ## don't turn on coturn's cli.
+    no-cli
+
+    pidfile="/var/tmp/turnserver.pid"
+
+    ## turn, stun.
+    listening-ip={{ default "__COTURN_EXT_IP__" .Values.coturnTurnListenIP }}
+    listening-port={{ .Values.coturnTurnListenPort }}
+    relay-ip={{ default "__COTURN_EXT_IP__" .Values.coturnTurnRelayIP }}
+    {{- if .Values.coturnTurnExternalIP }}
+    external-ip={{ default "__COTURN_EXT_IP__" .Values.coturnTurnExternalIP }}
+    {{- end }}
+    realm=dummy.io
+    no-stun-backward-compatibility
+    secure-stun
+    no-rfc5780
+
+    ## prometheus metrics
+    prometheus-ip={{ default "__COTURN_POD_IP__" .Values.coturnPrometheusIP }}
+    prometheus-port={{ .Values.coturnMetricsListenPort }}
+
+    ## logs
+    log-file=stdout
+    {{- if .Values.config.verboseLogging }}
+    verbose
+    {{- end }}
+
+    ## access control settings.
+    # the address ranges listed here are reserved for special use according
+    # to the iana registries for special-purposes ipv4 and ipv6 addresses. note
+    # however that these ranges do *not* include rfc1918 ipv4 space, or ula
+    # ipv6 space, as these may be valid peer addresses in some private network
+    # environments.
+    #
+    # ref:
+    # - https://www.iana.org/assignments/iana-ipv4-special-registry/iana-ipv4-special-registry.xhtml
+    # - https://www.iana.org/assignments/iana-ipv6-special-registry/iana-ipv6-special-registry.xhtml
+    # - https://www.rtcsec.com/article/cve-2020-26262-bypass-of-coturns-access-control-protection/#further-concerns-what-else
+    no-multicast-peers
+    denied-peer-ip=0.0.0.0-0.255.255.255
+    denied-peer-ip=100.64.0.0-100.127.255.255
+    denied-peer-ip=127.0.0.0-127.255.255.255
+    denied-peer-ip=169.254.0.0-169.254.255.255
+    denied-peer-ip=192.0.0.0-192.0.0.255
+    denied-peer-ip=192.0.2.0-192.0.2.255
+    denied-peer-ip=192.88.99.0-192.88.99.255
+    denied-peer-ip=198.18.0.0-198.19.255.255
+    denied-peer-ip=198.51.100.0-198.51.100.255
+    denied-peer-ip=203.0.113.0-203.0.113.255
+    denied-peer-ip=240.0.0.0-255.255.255.255
+    denied-peer-ip=::1
+    denied-peer-ip=64:ff9b::-64:ff9b::ffff:ffff
+    denied-peer-ip=::ffff:0.0.0.0-::ffff:255.255.255.255
+    denied-peer-ip=100::-100::ffff:ffff:ffff:ffff
+    denied-peer-ip=2001::-2001:1ff:ffff:ffff:ffff:ffff:ffff:ffff
+    denied-peer-ip=2002::-2002:ffff:ffff:ffff:ffff:ffff:ffff:ffff
+    # fc00::/7 is reserved for ipv6 ula, but fc00::/8 is not assigned at present.
+    denied-peer-ip=fc00::-fcff:ffff:ffff:ffff:ffff:ffff:ffff:ffff
+    denied-peer-ip=fe80::-febf:ffff:ffff:ffff:ffff:ffff:ffff:ffff
+
+    # FUTUREWORK: expose customisable access control settings.
+
+    ## authentication setup
+    zrest
+    ## static authentication secrets will be added below this line when the
+    ## runtime configuration is generated.
+
+    {{- if .Values.federate.enabled }}
+    ### federation setup
+    federation-listening-ip={{ default "__COTURN_EXT_IP__" .Values.coturnFederationListeningIP }}
+    federation-listening-port={{ .Values.federate.port }}
+    federation-no-dtls={{ not .Values.federate.dtls.enabled }}
+    {{- if .Values.federate.dtls.enabled }}
+    federation-cert=/coturn-dtls-certificate/tls.crt
+    federation-pkey=/coturn-dtls-certificate/tls.key
+    {{ if hasKey .Values.federate.dtls.tls "privateKeyPassword" }}
+    federation-pkey-pwd={{ .Values.federate.dtls.tls.privateKeyPassword }}
+    {{ end }}
+    # list of host/ip/cert common names / subject alt names, and optional issuer
+    # names to accept DTLS connections from. There can be multiple entries, each
+    # entry is formated as:
+    # <hostname>[,<issuer>]
+    {{ range $entry := .Values.federate.dtls.remoteWhitelist }}
+    federation-remote-whitelist={{ $entry.host }}{{ if hasKey $entry "issuer" }},{{ $entry.issuer }}{{end}}
+    {{ end }}
+    {{ end }}
+    {{ end }}

--- a/charts/coturn/templates/secret-or-certificate.yaml
+++ b/charts/coturn/templates/secret-or-certificate.yaml
@@ -1,0 +1,41 @@
+{{- if .Values.federate.dtls.enabled -}}
+
+{{- if .Values.federate.dtls.tls.issuerRef -}}
+{{- if or .Values.federate.dtls.tls.key  .Values.federate.dtls.tls.crt }}
+{{- fail "issuerRef and  {crt,key} are mutually exclusive" -}}
+{{- end -}}
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: "{{ include "coturn.fullname" . }}"
+  labels:
+    {{- include "coturn.labels" . | nindent 4 }}
+    {{- if .Values.federate.dtls.tls.certificate.labels }}
+    {{- toYaml .Values.federate.dtls.tls.certificate.labels | nindent 4}}
+    {{- end }}
+spec:
+  dnsNames:
+    {{- toYaml .Values.federate.dtls.tls.certificate.dnsNames | nindent 4 }}
+  secretName: coturn-dtls-certificate
+  issuerRef:
+    {{- toYaml .Values.federate.dtls.tls.issuerRef | nindent 4 }}
+  privateKey:
+    rotationPolicy: Always
+    algorithm: ECDSA
+    size: 384
+{{- else if and .Values.federate.dtls.tls.key  .Values.federate.dtls.tls.crt }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: coturn-dtls-certificate
+  labels:
+    {{- include "coturn.labels" . | nindent 4 }}
+type: Opaque
+data:
+  tls.key: {{ .Values.federate.dtls.tls.key | b64enc }}
+  tls.crt: {{ .Values.federate.dtls.tls.crt | b64enc }}
+{{- else -}}
+{{- fail "must specify tls.key and tls.crt , or tls.issuerRef" -}}
+{{- end -}}
+
+{{- end -}}

--- a/charts/coturn/templates/secret.yaml
+++ b/charts/coturn/templates/secret.yaml
@@ -1,0 +1,20 @@
+{{- if or (not .Values.secrets) (not .Values.secrets.zrestSecrets) }}
+{{- fail "TURN authentication secrets are not defined in .Values.secrets.zrestSecrets" }}
+{{- else if eq (len .Values.secrets.zrestSecrets) 0 }}
+{{- fail "At least one authentication secret must be defined" }}
+{{- else }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: coturn
+  labels:
+    app: coturn
+    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+type: Opaque
+stringData:
+  zrest_secret.txt: |
+    {{- range .Values.secrets.zrestSecrets }}{{ . | nindent 4 }}
+    {{- end }}
+{{- end }}

--- a/charts/coturn/templates/service-account.yaml
+++ b/charts/coturn/templates/service-account.yaml
@@ -1,0 +1,42 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: coturn
+  labels:
+    app: coturn
+    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: coturn-{{ .Release.Namespace }}
+  labels:
+    app: coturn
+    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+rules:
+  - apiGroups: [""]
+    resources: [nodes]
+    verbs: [get]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: coturn-{{ .Release.Namespace }}
+  labels:
+    app: coturn
+    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+roleRef:
+  kind: ClusterRole
+  apiGroup: rbac.authorization.k8s.io
+  name: coturn-{{ .Release.Namespace }}
+subjects:
+  - kind: ServiceAccount
+    name: coturn
+    namespace: {{ .Release.Namespace }}

--- a/charts/coturn/templates/service.yaml
+++ b/charts/coturn/templates/service.yaml
@@ -1,0 +1,37 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: coturn
+  labels:
+    app: coturn
+    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+  {{- with .Values.service.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  # Needs to be headless
+  # See: https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/
+  clusterIP: None
+  ports:
+    - name: coturn-tcp
+      port: {{ .Values.coturnTurnListenPort }}
+      targetPort: coturn-tcp
+    - name: coturn-udp
+      port: {{ .Values.coturnTurnListenPort }}
+      targetPort: coturn-udp
+      protocol: UDP
+    {{- if .Values.tls.enabled }}
+    - name: coturn-tls
+      port: {{ .Values.coturnTurnTlsListenPort }}
+      targetPort: coturn-tls
+    {{- end }}
+    - name: status-http
+      port: {{ .Values.coturnMetricsListenPort }}
+      targetPort: status-http
+  selector:
+    app: coturn
+    release: {{ .Release.Name }}

--- a/charts/coturn/templates/servicemonitor.yaml
+++ b/charts/coturn/templates/servicemonitor.yaml
@@ -1,0 +1,19 @@
+{{- if .Values.metrics.serviceMonitor.enabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: coturn
+  labels:
+    app: coturn
+    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+spec:
+  endpoints:
+    - port: status-http
+      path: /metrics
+  selector:
+    matchLabels:
+      app: coturn
+      release: {{ .Release.Name }}
+{{- end }}

--- a/charts/coturn/templates/statefulset.yaml
+++ b/charts/coturn/templates/statefulset.yaml
@@ -1,0 +1,218 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: coturn
+  labels:
+    app: coturn
+    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+
+spec:
+  replicas: {{ .Values.replicaCount }}
+
+  # Allow starting and stopping coturn in parallel when scaling. This does not
+  # affect upgrades.
+  podManagementPolicy: Parallel
+
+  serviceName: coturn
+  selector:
+    matchLabels:
+      app: coturn
+  template:
+    metadata:
+    {{- with .Values.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+    {{- end }}
+
+      labels:
+        app: coturn
+        release: {{ .Release.Name }}
+    spec:
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      {{- if .Values.tls.enabled }}
+      # Needed for automatic certificate reload handling
+      shareProcessNamespace: true
+      {{- end }}
+      hostNetwork: true
+      serviceAccountName: coturn
+      volumes:
+        - name: external-ip
+          emptyDir: {}
+        - name: coturn-config
+          emptyDir: {}
+        - name: coturn-config-template
+          configMap:
+            name: coturn
+        - name: secrets
+          secret:
+            secretName: coturn
+        - name: coturndb
+          emptyDir:
+            medium: Memory
+            sizeLimit: 128Mi # observed size: 80 kilobytes
+        {{- if .Values.tls.enabled }}
+        - name: secrets-tls
+          secret:
+            secretName: {{ .Values.tls.secretRef }}
+        {{- end }}
+        {{- if .Values.federate.dtls.enabled }}
+        - name: coturn-dtls-certificate
+          secret:
+            secretName: coturn-dtls-certificate
+        {{- end }}
+      initContainers:
+        - name: get-external-ip
+          image: bitnami/kubectl:1.24.12
+          volumeMounts:
+            - name: external-ip
+              mountPath: /external-ip
+          env:
+            - name: NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+          command:
+            - /bin/sh
+            - -c
+            - |
+              set -e
+  
+              # In the cloud, this setting is available to indicate the true IP address
+              addr=$(kubectl get node $NODE_NAME -ojsonpath='{.status.addresses[?(@.type=="ExternalIP")].address}')
+              # On on-prem we allow people to set  "wire.com/external-ip" to override this
+              if [ -z "$addr" ]; then
+                addr=$(kubectl get node $NODE_NAME -ojsonpath='{.metadata.annotations.wire\.com/external-ip}')
+              fi
+              echo -n "$addr" | tee /dev/stderr > /external-ip/ip
+      containers:
+        - name: {{ .Chart.Name }}
+          image: "{{ .Values.image.repository}}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          env:
+            - name: POD_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.podIP
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: HOST_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.hostIP
+          volumeMounts:
+            - name: external-ip
+              mountPath: /external-ip
+            - name: coturn-config
+              mountPath: /coturn-config
+            - name: coturn-config-template
+              mountPath: /coturn-template/coturn.conf.template
+              subPath: coturn.conf.template
+            - name: secrets
+              mountPath: /secrets/
+              readOnly: true
+            # > By default, Coturn Docker image persists its data in /var/lib/coturn/ directory.
+            # > You can speedup Coturn simply by using tmpfs for that.
+            # We use a memory-backed emptyDir here instead.
+            - name: coturndb
+              mountPath: /var/lib/coturn
+          {{- if .Values.tls.enabled }}
+            - name: secrets-tls
+              mountPath: /secrets-tls/
+              readOnly: true
+          {{- end }}
+           {{- if .Values.federate.dtls.enabled }}
+            - name: coturn-dtls-certificate
+              mountPath: /coturn-dtls-certificate/
+              readOnly: true
+           {{- end }}
+          command:
+            - /usr/bin/dumb-init
+            - --
+            - /bin/sh
+            - -c
+            - |
+              set -e
+              EXTERNAL_IP=$(cat /external-ip/ip)
+              sed -Ee "s;__COTURN_EXT_IP__;$EXTERNAL_IP;g" -e "s;__COTURN_POD_IP__;$POD_IP;g" -e "s;__COTURN_HOST_IP__;$HOST_IP;g" /coturn-template/coturn.conf.template > /coturn-config/turnserver.conf
+              sed -Ee 's/^/static-auth-secret=/' /secrets/zrest_secret.txt >> /coturn-config/turnserver.conf
+              exec /usr/bin/turnserver -c /coturn-config/turnserver.conf
+          {{- if .Values.coturnGracefulTermination }}
+          lifecycle:
+            preStop:
+              exec:
+                command:
+                  - /bin/sh
+                  - -c
+                  - "exec /usr/local/bin/pre-stop-hook \"$POD_IP\" {{ .Values.coturnMetricsListenPort }}"
+          {{- end }}
+
+          ports:
+            - name: coturn-tcp
+              containerPort: {{ .Values.coturnTurnListenPort }}
+              protocol: TCP
+            - name: coturn-udp
+              containerPort: {{ .Values.coturnTurnListenPort }}
+              protocol: UDP
+            {{- if .Values.tls.enabled }}
+            - name: coturn-tls
+              containerPort: {{ .Values.coturnTurnTlsListenPort }}
+              protocol: TCP
+            {{- end }}
+            - name: status-http
+              containerPort: {{ .Values.coturnMetricsListenPort }}
+              protocol: TCP
+
+          livenessProbe:
+            timeoutSeconds: {{ .Values.livenessProbe.timeoutSeconds }}
+            failureThreshold: {{ .Values.livenessProbe.failureThreshold }}
+            httpGet:
+              path: /
+              port: status-http
+
+          readinessProbe:
+            timeoutSeconds: {{ .Values.readinessProbe.timeoutSeconds }}
+            failureThreshold: {{ .Values.readinessProbe.failureThreshold }}
+            httpGet:
+              path: /
+              port: status-http
+
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+
+        {{- if .Values.tls.enabled }}
+        - name: {{ .Chart.Name }}-cert-reloader
+          image: "{{ .Values.tls.reloaderImage.repository }}:{{ .Values.tls.reloaderImage.tag }}"
+          imagePullPolicy: {{ .Values.tls.reloaderImage.pullPolicy }}
+          env:
+            - name: CONFIG_DIR
+              value: /secrets-tls
+            - name: PROCESS_NAME
+              value: turnserver
+            - name: RELOAD_SIGNAL
+              value: SIGUSR2
+          volumeMounts:
+            - name: secrets-tls
+              mountPath: /secrets-tls/
+              readOnly: true
+        {{- end }}
+
+      {{- if .Values.coturnGracefulTermination }}
+      terminationGracePeriodSeconds: {{ .Values.coturnGracePeriodSeconds }}
+      {{- end }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/charts/coturn/values.yaml
+++ b/charts/coturn/values.yaml
@@ -1,0 +1,120 @@
+# The amount of coturn instances to run.  NOTE: Only one coturn can run per node due
+# to `hostNetwork`. If this number is higher than the amount of nodes that can
+# be used for scheduling (Also see `nodeSelector`) pods will remain in a
+# pending state untill you add more capacity.
+replicaCount: 1
+
+image:
+  repository: quay.io/wire/coturn
+  pullPolicy: IfNotPresent
+  # overwrite the tag here, otherwise `appVersion` of the chart will be used
+  tag: ""
+
+# If you have multiple deployments of coturn running in one cluster, it is
+# important that they run on disjoint sets of nodes, you can use nodeSelector to enforce this
+nodeSelector: {}
+
+podSecurityContext:
+  fsGroup: 31338
+
+securityContext:
+  # Pick a high number that is unlikely to conflict with the host
+  # https://kubesec.io/basics/containers-securitycontext-runasuser/
+  runAsUser: 31338
+
+coturnTurnListenPort: 3478
+coturnMetricsListenPort: 9641
+coturnTurnTlsListenPort: 5349
+
+# coturnTurnListenIP: "1.2.3.4" # can also be __COTURN_EXT_IP__, __COTURN_POD_IP__,__COTURN_HOST_IP__
+coturnTurnExternalIP: null
+# coturnTurnRelayIP:
+# coturnPrometheusIP:
+# coturnFederationListeningIP:
+
+tls:
+  enabled: false
+  # compliant with BSI TR-02102-2
+  ciphers: 'ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:TLS_AES_128_GCM_SHA256:TLS_AES_256_GCM_SHA384'
+  secretRef:
+  reloaderImage:
+    # container image containing https://github.com/Pluies/config-reloader-sidecar
+    # for handling runtime certificate reloads.
+    repository: quay.io/wire/config-reloader-sidecar
+    pullPolicy: IfNotPresent
+    tag: 72c3c8434660bd157d42012b0bcd67f338fc5c7a
+
+config:
+  verboseLogging: false
+
+federate:
+  enabled: false
+  port: 9191
+
+  dtls:
+    enabled: false
+
+    tls:
+  #   Example:
+  #
+  #   tls:
+  #     key: "-----BEGIN EC PRIVATE KEY----- ..." # (ascii blob) private key
+  #     crt: "-----BEGIN CERTIFICATE----- ..." # (ascii blob) certificate
+  #     privateKeyPassword: "XXX" # optional, used when the key is password protected
+  #
+  #   OR (mutually exclusive)
+  #
+  #   tls:
+  #      issuerRef:
+  #        name: letsencrypt-http01
+  #
+  #        # We can reference ClusterIssuers by changing the kind here.
+  #        # The default value is Issuer (i.e. a locally namespaced Issuer)
+  #        # kind: Issuer
+  #        kind: Issuer
+  #
+  #        # This is optional since cert-manager will default to this value however
+  #        # if you are using an external issuer, change this to that issuer group.
+  #        group: cert-manager.io
+  #
+  #      # optional labels to attach to the cert-manager Certificate
+  #      certificate:
+  #        labels: ..
+
+  # # list of host/ip/cert common names / subject alt names, and optional issuer
+  # # names to accept DTLS connections from. There can be multiple entries.
+  # remoteWhitelist:
+  #   - host: wire.example
+  #     issuer: Issuer Common Name
+  #   - host: another.wire.example
+  #     issuer: "DigiCert SHA2 Extended Validation Server CA"
+  #   - host: another-host-without-issuer.wire.example
+    remoteWhitelist: []
+
+metrics:
+  serviceMonitor:
+    enabled: false
+
+# This chart supports waiting for traffic to drain from coturn
+# before pods are actually terminated. Once in 'drain' mode, no new connections
+# are accepted, but old ones are kept alive.
+# If you have 2 or more replicas, it's recommended to set this to true,
+# and if you only have one coturn replica you may want this to be false, as
+# otherwise while the pod restarts, no new calls can be established.
+coturnGracefulTermination: false
+# Grace period for terminating coturn pods, after which they will be forcibly
+# terminated. This setting is only effective when coturnGracefulTermination is
+# set to true.
+coturnGracePeriodSeconds: 43200 # 12 hours
+
+livenessProbe:
+  timeoutSeconds: 5
+  failureThreshold: 5
+
+readinessProbe:
+  timeoutSeconds: 5
+  failureThreshold: 5
+
+service:
+  # Kubernetes annotations to be set at the Service
+  annotations: {}


### PR DESCRIPTION
This PR migrates the coturn helm chart from https://github.com/wireapp/wire-server/tree/develop/charts/coturn at commit https://github.com/wireapp/wire-server/commit/20f888c339
