### PR TITLE
WPB-12084: Rate-limit 401 Unauthorized responses to prevent abuse/reflection (upstream changes)

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -13,7 +13,7 @@ LIBCLIENTTURN_DEPS = ${LIBCLIENTTURN_HEADERS} ${MAKE_DEPS}
 LIBCLIENTTURN_OBJS = build/obj/ns_turn_ioaddr.o build/obj/ns_turn_msg_addr.o build/obj/ns_turn_msg.o 
 
 SERVERTURN_HEADERS = src/server/ns_turn_allocation.h src/server/ns_turn_ioalib.h src/server/ns_turn_khash.h src/server/ns_turn_maps_rtcp.h src/server/ns_turn_maps.h src/server/ns_turn_server.h src/server/ns_turn_session.h  src/server/ns_turn_ratelimit.h
-SERVERTURN_DEPS = ${LIBCLIENTTURN_HEADERS} ${SERVERTURN_HEADERS} ${MAKE_DEPS} 
+SERVERTURN_DEPS = ${LIBCLIENTTURN_HEADERS} ${SERVERTURN_HEADERS} ${MAKE_DEPS}
 SERVERTURN_MODS = ${LIBCLIENTTURN_MODS} src/server/ns_turn_allocation.c src/server/ns_turn_maps_rtcp.c src/server/ns_turn_maps.c src/server/ns_turn_server.c src/server/ns_turn_ratelimit.c
 
 COMMON_HEADERS = src/apps/common/apputils.h src/apps/common/ns_turn_openssl.h src/apps/common/ns_turn_utils.h src/apps/common/stun_buffer.h

--- a/README.turnserver
+++ b/README.turnserver
@@ -678,6 +678,10 @@ Options with values:
                     Strongly encouraged to use this option to decrease gain factor in STUN binding responses.
 --no-stun-backward-compatibility		Disable handling old STUN Binding requests and disable MAPPED-ADDRESS attribute in binding response (use only the XOR-MAPPED-ADDRESS).
 --response-origin-only-with-rfc5780		Only send RESPONSE-ORIGIN attribute in binding response if RFC5780 is enabled.
+--401-req-limit=<request>   Set the maximum number of 401 Unauthorized responses allowed per rate-limiting window.
+                            Defaults is 1000.
+--401-window=<seconds>      Set the time window duration in seconds for rate limiting 401 Unauthorized responses.
+                            Defaults is 120.
 					
 
 ==================================

--- a/src/apps/relay/mainrelay.h
+++ b/src/apps/relay/mainrelay.h
@@ -351,6 +351,9 @@ typedef struct _turn_params_ {
   vint log_binding;
   vint no_stun_backward_compatibility;
   vint response_origin_only_with_rfc5780;
+
+  vint ratelimit_401_requests_per_window;
+  vint ratelimit_401_window_seconds;
 } turn_params_t;
 
 extern turn_params_t turn_params;

--- a/src/apps/relay/netengine.c
+++ b/src/apps/relay/netengine.c
@@ -1695,7 +1695,9 @@ static void setup_relay_server(struct relay_server *rs, ioa_engine_handle e, int
                    send_turn_session_info, send_https_socket, allocate_bps, turn_params.oauth,
                    turn_params.oauth_server_name, turn_params.acme_redirect,
                    turn_params.allocation_default_address_family, &turn_params.log_binding,
-                   &turn_params.no_stun_backward_compatibility, &turn_params.response_origin_only_with_rfc5780);
+                   &turn_params.no_stun_backward_compatibility, &turn_params.response_origin_only_with_rfc5780,
+                   &turn_params.ratelimit_401_requests_per_window, &turn_params.ratelimit_401_window_seconds);
+
 
   // Intentionally performed outside init_turn_server to help avoid future merge conflicts
   if(turn_params.federation_listening_ip != NULL && 

--- a/src/ns_turn_defs.h
+++ b/src/ns_turn_defs.h
@@ -31,7 +31,7 @@
 #ifndef __IOADEFS__
 #define __IOADEFS__
 
-#define TURN_SERVER_VERSION "wireapp/4.6.2e"
+#define TURN_SERVER_VERSION "wireapp/4.6.2f"
 #define TURN_SERVER_VERSION_NAME "Gorst"
 #ifndef TURN_SERVER_BUILD_INFO
 #define TURN_SERVER_BUILD_INFO ""

--- a/src/server/ns_turn_maps.c
+++ b/src/server/ns_turn_maps.c
@@ -719,7 +719,7 @@ static size_t addr_list_size(const addr_list_header *slh) {
   return ret;
 }
 
-static addr_elem *_addr_list_get(addr_list_header *slh, const ioa_addr *key, int port) {
+static addr_elem *addr_list_get(addr_list_header *slh, const ioa_addr *key) {
 
   if (!slh || !key)
     return NULL;
@@ -729,14 +729,8 @@ static addr_elem *_addr_list_get(addr_list_header *slh, const ioa_addr *key, int
   for (i = 0; i < ADDR_ARRAY_SIZE; ++i) {
     addr_elem *elem = &(slh->main_list[i]);
     if (elem->value) {
-      if (port) {
-        if (addr_eq(&(elem->key), key)) {
-          return elem;
-        }
-      } else {
-        if (addr_eq_no_port(&(elem->key), key)) {
-          return elem;
-        }
+      if (addr_eq(&(elem->key), key)) {
+        return elem;
       }
     }
   }
@@ -745,14 +739,8 @@ static addr_elem *_addr_list_get(addr_list_header *slh, const ioa_addr *key, int
     for (i = 0; i < slh->extra_sz; ++i) {
       addr_elem *elem = &(slh->extra_list[i]);
       if (elem->value) {
-        if (port) {
-          if (addr_eq(&(elem->key), key)) {
-            return elem;
-          }
-        } else {
-          if (addr_eq_no_port(&(elem->key), key)) {
-            return elem;
-          }
+        if (addr_eq(&(elem->key), key)) {
+          return elem;
         }
       }
     }
@@ -761,15 +749,7 @@ static addr_elem *_addr_list_get(addr_list_header *slh, const ioa_addr *key, int
   return NULL;
 }
 
-static addr_elem *addr_list_get_no_port(addr_list_header *slh, const ioa_addr *key) {
-  return _addr_list_get(slh, key, 0);
-}
-
-static addr_elem *addr_list_get(addr_list_header *slh, const ioa_addr *key) {
-  return _addr_list_get(slh, key, 1);
-}
-
-static const addr_elem *_addr_list_get_const(const addr_list_header *slh, const ioa_addr *key, int port) {
+static const addr_elem *addr_list_get_const(const addr_list_header *slh, const ioa_addr *key) {
 
   if (!slh || !key)
     return NULL;
@@ -779,14 +759,8 @@ static const addr_elem *_addr_list_get_const(const addr_list_header *slh, const 
   for (i = 0; i < ADDR_ARRAY_SIZE; ++i) {
     const addr_elem *elem = &(slh->main_list[i]);
     if (elem->value) {
-      if (port) {
-        if (addr_eq(&(elem->key), key)) {
-          return elem;
-        }
-      } else {
-        if (addr_eq_no_port(&(elem->key), key)) {
-          return elem;
-        }
+      if (addr_eq(&(elem->key), key)) {
+        return elem;
       }
     }
   }
@@ -795,14 +769,8 @@ static const addr_elem *_addr_list_get_const(const addr_list_header *slh, const 
     for (i = 0; i < slh->extra_sz; ++i) {
       const addr_elem *elem = &(slh->extra_list[i]);
       if (elem->value) {
-        if (port) {
-          if (addr_eq(&(elem->key), key)) {
-            return elem;
-          }
-        } else {
-          if (addr_eq_no_port(&(elem->key), key)) {
-            return elem;
-          }
+        if (addr_eq(&(elem->key), key)) {
+          return elem;
         }
       }
     }
@@ -811,21 +779,11 @@ static const addr_elem *_addr_list_get_const(const addr_list_header *slh, const 
   return NULL;
 }
 
-static const addr_elem *addr_list_get_const_no_port(const addr_list_header *slh, const ioa_addr *key) {
-  return _addr_list_get_const(slh, key, 0);
-}
-
-static const addr_elem *addr_list_get_const(const addr_list_header *slh, const ioa_addr *key) {
-  return _addr_list_get_const(slh, key, 1);
-}
-
 ////////// ADDR MAPS ////////////////////////////////////////////
 
 #define addr_map_index(key) (addr_hash((key)) & (ADDR_MAP_SIZE - 1))
-#define addr_map_index_no_port(key) (addr_hash_no_port((key)) & (ADDR_MAP_SIZE - 1))
 
 #define get_addr_list_header(map, key) (&((map)->lists[addr_map_index((key))]))
-#define get_addr_list_header_no_port(map, key) (&((map)->lists[addr_map_index_no_port((key))]))
 
 #define ur_addr_map_valid(map) ((map) && ((map)->magic == MAGIC_HASH))
 
@@ -852,22 +810,16 @@ void ur_addr_map_clean(ur_addr_map *map) {
  * -1 - error
  * if the addr key exists, the value is updated.
  */
-int _ur_addr_map_put(ur_addr_map *map, ioa_addr *key, ur_addr_map_value_type value, int port) {
+int ur_addr_map_put(ur_addr_map *map, ioa_addr *key, ur_addr_map_value_type value) {
 
   if (!ur_addr_map_valid(map))
     return -1;
 
   else {
-    addr_list_header *slh = NULL;
-    addr_elem *elem = NULL;
-    if (port) {
-      slh = get_addr_list_header(map, key);
-      elem = addr_list_get(slh, key);
-    } else {
-      slh = get_addr_list_header_no_port(map, key);
-      elem = addr_list_get_no_port(slh, key);
-    }
 
+    addr_list_header *slh = get_addr_list_header(map, key);
+
+    addr_elem *elem = addr_list_get(slh, key);
     if (elem) {
       elem->value = value;
     } else {
@@ -880,42 +832,19 @@ int _ur_addr_map_put(ur_addr_map *map, ioa_addr *key, ur_addr_map_value_type val
 
 /**
  * @ret:
- * 0 - success
- * -1 - error
- * if the addr key exists, the value is updated.
- */
-int ur_addr_map_put_no_port(ur_addr_map *map, ioa_addr *key, ur_addr_map_value_type value) {
-  return _ur_addr_map_put(map, key, value, 0);
-}
-
-int ur_addr_map_put(ur_addr_map *map, ioa_addr *key, ur_addr_map_value_type value) {
-  return _ur_addr_map_put(map, key, value, 1);
-}
-
-/**
- * @ret:
  * 1 - success
  * 0 - not found
  */
-int _ur_addr_map_get(const ur_addr_map *map, ioa_addr *key, ur_addr_map_value_type *value, int port) {
+int ur_addr_map_get(const ur_addr_map *map, ioa_addr *key, ur_addr_map_value_type *value) {
 
   if (!ur_addr_map_valid(map))
     return 0;
 
   else {
 
-    const addr_list_header *slh = NULL;
-    const addr_elem *elem = NULL;
+    const addr_list_header *slh = get_addr_list_header(map, key);
 
-    if (port) {
-      slh = get_addr_list_header(map, key);
-      elem = addr_list_get_const(slh, key);
-
-    } else {
-      slh = get_addr_list_header_no_port(map, key);
-      elem = addr_list_get_const_no_port(slh, key);
-    }
-
+    const addr_elem *elem = addr_list_get_const(slh, key);
     if (elem) {
       if (value)
         *value = elem->value;
@@ -924,19 +853,6 @@ int _ur_addr_map_get(const ur_addr_map *map, ioa_addr *key, ur_addr_map_value_ty
 
     return 0;
   }
-}
-
-/**
- * @ret:
- * 1 - success
- * 0 - not found
- */
-int ur_addr_map_get_no_port(const ur_addr_map *map, ioa_addr *key, ur_addr_map_value_type *value) {
-  return _ur_addr_map_get(map, key, value, 0);
-}
-
-int ur_addr_map_get(const ur_addr_map *map, ioa_addr *key, ur_addr_map_value_type *value) {
-  return _ur_addr_map_get(map, key, value, 1);
 }
 
 /**
@@ -1034,7 +950,7 @@ int addr_list_foreach_del_condition(ur_addr_map *map, ur_addr_map_cond_func func
           if (func(elem->value)) {
             free((void *)elem->value);
             memset(&(elem->key), 0, sizeof(ioa_addr));
-            elem->value = 0;
+            elem->value = NULL;
             count++;
           }
         }
@@ -1047,7 +963,7 @@ int addr_list_foreach_del_condition(ur_addr_map *map, ur_addr_map_cond_func func
             if (func(elem->value)) {
               free((void *)elem->value);
               memset(&(elem->key), 0, sizeof(ioa_addr));
-              elem->value = 0;
+              elem->value = NULL;
               count++;
             }
           }

--- a/src/server/ns_turn_maps.h
+++ b/src/server/ns_turn_maps.h
@@ -48,6 +48,7 @@ typedef uint64_t ur_map_key_type;
 typedef uintptr_t ur_map_value_type;
 
 typedef void (*ur_map_del_func)(ur_map_value_type);
+typedef int (ur_addr_map_cond_func)(ur_addr_map_value_type);
 
 typedef int (*foreachcb_type)(ur_map_key_type key, ur_map_value_type value);
 typedef int (*foreachcb_arg_type)(ur_map_key_type key, ur_map_value_type value, void *arg);
@@ -181,7 +182,6 @@ struct _ur_addr_map;
 typedef struct _ur_addr_map ur_addr_map;
 
 typedef void (*ur_addr_map_func)(ur_addr_map_value_type);
-typedef int (ur_addr_map_cond_func)(ur_addr_map_value_type);
 
 void ur_addr_map_init(ur_addr_map *map);
 void ur_addr_map_clean(ur_addr_map *map);
@@ -192,18 +192,14 @@ void ur_addr_map_clean(ur_addr_map *map);
  * -1 - error
  * if the addr key exists, the value is updated.
  */
-int _ur_addr_map_put(ur_addr_map *map, ioa_addr *key, ur_addr_map_value_type value, int port);
 int ur_addr_map_put(ur_addr_map *map, ioa_addr *key, ur_addr_map_value_type value);
-int ur_addr_map_put_no_port(ur_addr_map *map, ioa_addr *key, ur_addr_map_value_type value);
 
 /**
  * @ret:
  * 1 - success
  * 0 - not found
  */
-int _ur_addr_map_get(const ur_addr_map *map, ioa_addr *key, ur_addr_map_value_type *value, int port);
 int ur_addr_map_get(const ur_addr_map *map, ioa_addr *key, ur_addr_map_value_type *value);
-int ur_addr_map_get_no_port(const ur_addr_map *map, ioa_addr *key, ur_addr_map_value_type *value);
 
 /**
  * @ret:

--- a/src/server/ns_turn_ratelimit.h
+++ b/src/server/ns_turn_ratelimit.h
@@ -38,14 +38,14 @@
 extern "C" {
 #endif
 
-int ratelimit_is_address_limited(ioa_addr *address);
+int ratelimit_is_address_limited(ioa_addr *address, int max_requests, int window_seconds);
 void ratelimit_add_node(ioa_addr *address);
 int ratelimit_delete_expired(ur_map_value_type value);
 void ratelimit_init_map(void);
 ////// Rate limit for 401 Unauthorized //////
 
-#define RATE_LIMIT_MAX_REQUESTS_PER_WINDOW 100
-#define RATE_LIMIT_WINDOW_SECS 60
+#define RATELIMIT_DEFAULT_MAX_REQUESTS_PER_WINDOW 1000
+#define RATELIMIT_DEFAULT_WINDOW_SECS 120
 
 typedef struct {
   time_t last_request_time;

--- a/src/server/ns_turn_server.c
+++ b/src/server/ns_turn_server.c
@@ -3919,10 +3919,9 @@ static int handle_turn_command(turn_turnserver *server, ts_ur_super_session *ss,
 
     *resp_constructed = 1;
   }
-
-  if(err_code == 401) {
+  if(err_code == 401 && *server->ratelimit_401_requests_per_window > 0) {
       ioa_addr *rate_limit_address = get_remote_addr_from_ioa_socket(ss->client_socket);
-      if (ratelimit_is_address_limited(rate_limit_address)) {
+      if (ratelimit_is_address_limited(rate_limit_address, *server->ratelimit_401_requests_per_window, *server->ratelimit_401_window_seconds)) {
           no_response = 1;
           char raddr[129];
           addr_to_string_no_port(rate_limit_address, (unsigned char *)raddr);
@@ -4929,7 +4928,8 @@ void init_turn_server(turn_turnserver *server, turnserver_id id, int verbose, io
                       allocate_bps_cb allocate_bps_func, int oauth, const char *oauth_server_name,
                       const char *acme_redirect, ALLOCATION_DEFAULT_ADDRESS_FAMILY allocation_default_address_family,
                       vintp log_binding, vintp no_stun_backward_compatibility,
-                      vintp response_origin_only_with_rfc5780) {
+                      vintp response_origin_only_with_rfc5780,
+                      vintp ratelimit_401_requests_per_window, vintp ratelimit_401_window_seconds) {
 
   if (!server)
     return;
@@ -5009,6 +5009,8 @@ void init_turn_server(turn_turnserver *server, turnserver_id id, int verbose, io
   server->response_origin_only_with_rfc5780 = response_origin_only_with_rfc5780;
 
   server->is_draining = 0;
+  server->ratelimit_401_requests_per_window = ratelimit_401_requests_per_window;
+  server->ratelimit_401_window_seconds = ratelimit_401_window_seconds;
 }
 
 ioa_engine_handle turn_server_get_engine(turn_turnserver *s) {

--- a/src/server/ns_turn_server.h
+++ b/src/server/ns_turn_server.h
@@ -209,6 +209,9 @@ struct _turn_turnserver {
   /* Federation params */
   ioa_addr federation_addr;
   void **federation_service;
+
+  vintp ratelimit_401_requests_per_window;
+  vintp ratelimit_401_window_seconds;
 };
 
 const char *get_version(turn_turnserver *server);
@@ -230,7 +233,8 @@ void init_turn_server(turn_turnserver *server, turnserver_id id, int verbose, io
                       send_turn_session_info_cb send_turn_session_info, send_https_socket_cb send_https_socket,
                       allocate_bps_cb allocate_bps_func, int oauth, const char *oauth_server_name,
                       const char *acme_redirect, ALLOCATION_DEFAULT_ADDRESS_FAMILY allocation_default_address_family,
-                      vintp log_binding, vintp no_stun_backward_compatibility, vintp response_origin_only_with_rfc5780);
+                      vintp log_binding, vintp no_stun_backward_compatibility, vintp response_origin_only_with_rfc5780,
+                      vintp ratelimit_401_requests_per_window, vintp ratelimit_401_window_seconds);
 
 ioa_engine_handle turn_server_get_engine(turn_turnserver *s);
 


### PR DESCRIPTION
Added rate-limiting to 401 Unauthorized responses to prevent abuse of the server for use in DDoS attacks via traffic reflection and amplification.

This patch works by counting the amount of requests that result in a 401 Unauthorized response and limiting them by IP Address if the occurred in a specified window of time.

Changes for upstream:

- Removed `ur_map` functions for no_port, instead setting port to 0 in a copy of the `ioa_addr` for simplicity.
- Added new command-line options:

--401-req-limit - Sets the amount of requests that result a 401 response per rate-limt window. If set to 0 disables 401 rate limiting.
--401-window - Sets the size in seconds of the rate-limit window.

- Bumped the version string to `wireapp/4.6.2f`

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Upstream pull request of this feature has more functionality than our original implementation, such as the ability to disable 401 rate limiting, and change the requests and window options.
 
### Solutions

Back ported the changes.

##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
