### PR TITLE
WPB-15070 - Make calls to ur_addr_map_get thread safe by introducing locks 

### DIFF
--- a/src/ns_turn_defs.h
+++ b/src/ns_turn_defs.h
@@ -31,7 +31,7 @@
 #ifndef __IOADEFS__
 #define __IOADEFS__
 
-#define TURN_SERVER_VERSION "wireapp/4.6.2h"
+#define TURN_SERVER_VERSION "wireapp/4.6.2j"
 #define TURN_SERVER_VERSION_NAME "Gorst"
 #ifndef TURN_SERVER_BUILD_INFO
 #define TURN_SERVER_BUILD_INFO ""

--- a/src/server/ns_turn_ratelimit.c
+++ b/src/server/ns_turn_ratelimit.c
@@ -86,7 +86,12 @@ int ratelimit_is_address_limited(ioa_addr *address, int max_requests, int window
   *address_new = *address;
   addr_set_port(address_new, 0);
 
+  /* Set global lock for `ur_addr_map_get` */
+  TURN_MUTEX_LOCK(&rate_limit_main_mutex);
   if (ur_addr_map_get(rate_limit_map, address_new, &ratelimit_ptr)) {
+    /* Unlock global lock from `ur_addr_map_get` */
+    TURN_MUTEX_UNLOCK(&rate_limit_main_mutex);
+
     free(address_new);
     ratelimit_entry *rateLimitEntry = (ratelimit_entry *)(void *)(ur_map_value_type)ratelimit_ptr;
     TURN_MUTEX_LOCK(&(rateLimitEntry->mutex));
@@ -105,6 +110,9 @@ int ratelimit_is_address_limited(ioa_addr *address, int max_requests, int window
       TURN_MUTEX_UNLOCK(&(rateLimitEntry->mutex));
       return 0;
     } else {
+      /* Unlock global lock from `ur_addr_map_get` */
+      TURN_MUTEX_UNLOCK(&rate_limit_main_mutex);
+
       /* Request is outside of defined window and count, request is ratelimited */
       if (rateLimitEntry->request_count < UINT32_MAX)
         rateLimitEntry->request_count++;


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Calls to `ur_addr_map_get` are not thread-safe.

### Solutions

Add global locks around calls to `ur_addr_map_get`


Needs releases with:

- [ ] GitHub link to other pull request

### Testing

#### Test Coverage (Optional)

- [ ] I have added automated test to this contribution

#### How to Test

_Briefly describe how this change was tested and if applicable the exact steps taken to verify that it works as expected._

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
