### PR TITLE
feat: add while loop with max tries to wait until the ext ip address …

### DIFF
--- a/charts/coturn/templates/statefulset.yaml
+++ b/charts/coturn/templates/statefulset.yaml
@@ -98,7 +98,7 @@ spec:
 
                 if [ -n "$addr" ]; then
                   echo -n "$addr" | tee /dev/stderr > /external-ip/ip
-                  break  # Exit loop once IP is found
+                  break
                 fi
 
                 count=$((count + 1))

--- a/charts/coturn/templates/statefulset.yaml
+++ b/charts/coturn/templates/statefulset.yaml
@@ -84,14 +84,32 @@ spec:
             - -c
             - |
               set -e
-  
-              # In the cloud, this setting is available to indicate the true IP address
-              addr=$(kubectl get node $NODE_NAME -ojsonpath='{.status.addresses[?(@.type=="ExternalIP")].address}')
-              # On on-prem we allow people to set  "wire.com/external-ip" to override this
+              max_tries=30
+              count=0
+
+              while [ "$count" -lt "$max_tries" ]; do
+                # In the cloud, this setting is available to indicate the true IP address
+                addr=$(kubectl get node $NODE_NAME -ojsonpath='{.status.addresses[?(@.type=="ExternalIP")].address}')
+                
+                # On on-prem we allow people to set "wire.com/external-ip" to override this
+                if [ -z "$addr" ]; then
+                  addr=$(kubectl get node $NODE_NAME -ojsonpath='{.metadata.annotations.wire\.com/external-ip}')
+                fi
+
+                if [ -n "$addr" ]; then
+                  echo -n "$addr" | tee /dev/stderr > /external-ip/ip
+                  break  # Exit loop once IP is found
+                fi
+
+                count=$((count + 1))
+                echo "Waiting for external IP... ($count/$max_tries)"
+                sleep 10
+              done
+
               if [ -z "$addr" ]; then
-                addr=$(kubectl get node $NODE_NAME -ojsonpath='{.metadata.annotations.wire\.com/external-ip}')
+                echo "Error: No external IP found after $max_tries attempts." >&2
+                exit 1
               fi
-              echo -n "$addr" | tee /dev/stderr > /external-ip/ip
       containers:
         - name: {{ .Chart.Name }}
           image: "{{ .Values.image.repository}}:{{ .Values.image.tag | default .Chart.AppVersion }}"

--- a/charts/coturn/templates/statefulset.yaml
+++ b/charts/coturn/templates/statefulset.yaml
@@ -91,7 +91,7 @@ spec:
                 # In the cloud, this setting is available to indicate the true IP address
                 addr=$(kubectl get node $NODE_NAME -ojsonpath='{.status.addresses[?(@.type=="ExternalIP")].address}')
                 
-                # On on-prem we allow people to set "wire.com/external-ip" to override this
+                # On on-prem we allow people to set "wire.com/external-ip" to be used if no ExternalIP is detected
                 if [ -z "$addr" ]; then
                   addr=$(kubectl get node $NODE_NAME -ojsonpath='{.metadata.annotations.wire\.com/external-ip}')
                 fi


### PR DESCRIPTION
Ticket: https://wearezeta.atlassian.net/browse/WPB-16320

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
Calling was not working on Stackit, possibly because of node restarts and coturn coming up before the controller assigned external IPs to the nodes.

----

# What's new in this PR?

### Issues

the initContainer needs to wait when there’s no external IP available, now the container is killed after 1 try without any wait time

### Solutions

Added wile loop that checks if External IP is assigned to the node every 10 seconds for maximum 30 times. 

### Testing

Tested on Stackit demo-b k8s cluster
