### PR TITLE
Revert "WPB-15216: fix no-dtls in coturn helm chart"

### DIFF
--- a/charts/coturn/templates/configmap-coturn-conf-template.yaml
+++ b/charts/coturn/templates/configmap-coturn-conf-template.yaml
@@ -6,12 +6,7 @@ metadata:
 data:
   coturn.conf.template: |
     ## disable dtls control plane; don't permit relaying tcp connections.
-    ## dtls handling
-    {{- if .Values.federate.dtls.enabled }}
-    # no-dtls
-    {{- else }}
     no-dtls
-    {{- end }}
     no-tcp-relay
 
     ## tls handling


### PR DESCRIPTION
Reverts wireapp/coturn#33 , as while it compiles, the test suite is not happy.