### PR TITLE
Coturn memory limits

### DIFF
--- a/charts/coturn/templates/statefulset.yaml
+++ b/charts/coturn/templates/statefulset.yaml
@@ -71,6 +71,8 @@ spec:
       initContainers:
         - name: get-external-ip
           image: bitnami/kubectl:1.29.11
+          resources:
+            {{- toYaml .Values.initResources | nindent 6 }}
           volumeMounts:
             - name: external-ip
               mountPath: /external-ip

--- a/charts/coturn/templates/statefulset.yaml
+++ b/charts/coturn/templates/statefulset.yaml
@@ -72,7 +72,7 @@ spec:
         - name: get-external-ip
           image: bitnami/kubectl:1.29.11
           resources:
-            {{- toYaml .Values.initResources | nindent 6 }}
+            {{- toYaml .Values.initResources | nindent 12 }}
           volumeMounts:
             - name: external-ip
               mountPath: /external-ip

--- a/charts/coturn/values.yaml
+++ b/charts/coturn/values.yaml
@@ -18,15 +18,15 @@ nodeSelector: {}
 # This is to prevent the pod from being OOM kill
 resources:
   requests:
-    memory: "512Mi"
+    memory: 512Mi
   limits:
-    memory: "6.5Gi"
+    memory: 6.5Gi
 
 initResources:
   requests:
-    memory: "64Mi"
+    memory: 64Mi
   limits:
-    memory: "256Mi"
+    memory: 256Mi
 
 podSecurityContext:
   fsGroup: 31338

--- a/charts/coturn/values.yaml
+++ b/charts/coturn/values.yaml
@@ -14,6 +14,20 @@ image:
 # important that they run on disjoint sets of nodes, you can use nodeSelector to enforce this
 nodeSelector: {}
 
+# Limiting memory usage to ~90% of the available memory on a 8Gb node which is used for coturn pods by default.
+# This is to prevent the pod from being OOM kill
+resources:
+  requests:
+    memory: "512Mi"
+  limits:
+    memory: "6.5Gi"
+
+initResources:
+  requests:
+    memory: "64Mi"
+  limits:
+    memory: "256Mi"
+
 podSecurityContext:
   fsGroup: 31338
 


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Ticket: https://wearezeta.atlassian.net/browse/WPB-17788

Memory leaks brought the whole node down. This should not happen

This ticket was created during [Incident INC-123 Coturn leaking memory after federation related configuration change](https://app.incident.io/wire/incidents/123) and was exported by Mathias Staab, using [incident.io](https://app.incident.io/) 🔥

The parent Jira ticket for this incident is [WPB-17666](https://wearezeta.atlassian.net/browse/WPB-17666)

### Solutions

Add limits. up to 90% node mem to coturn and also limits for initContainer

### Testing
Tested on calling-staging

[WPB-17666]: https://wearezeta.atlassian.net/browse/WPB-17666?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ