### PR TITLE
feat: make CA certificate bundle configurable in Helm chart

### DIFF
--- a/charts/coturn/templates/configmap-coturn-conf-template.yaml
+++ b/charts/coturn/templates/configmap-coturn-conf-template.yaml
@@ -20,8 +20,18 @@ data:
     no-tls
     {{- end }}
 
-    # This is mandatory for federated DTLS
+    # Certificate authority validation
+    {{- if .Values.ca.enabled }}
+    {{- if .Values.ca.secretRef }}
+    # Custom CA bundle from Kubernetes Secret
+    CA-file=/secrets-ca/{{ .Values.ca.secretKey }}
+    {{- else }}
+    # CA validation explicitly disabled
+    {{- end }}
+    {{- else }}
+    # Default system CA bundle
     CA-file=/etc/ssl/certs/ca-certificates.crt
+    {{- end }}
 
     ## don't turn on coturn's cli.
     no-cli

--- a/charts/coturn/templates/configmap-coturn-conf-template.yaml
+++ b/charts/coturn/templates/configmap-coturn-conf-template.yaml
@@ -22,9 +22,9 @@ data:
 
     # Certificate authority validation
     {{- if .Values.ca.enabled }}
-    {{- if .Values.ca.secretRef }}
+    {{- if or .Values.ca.secretRef .Values.ca.cert }}
     # Custom CA bundle from Kubernetes Secret
-    CA-file=/secrets-ca/{{ .Values.ca.secretKey }}
+    CA-file=/secrets-ca/{{ .Values.ca.secretKey | default "ca-certificates.crt" }}
     {{- else }}
     # CA validation explicitly disabled
     {{- end }}

--- a/charts/coturn/templates/secret-ca-certificate.yaml
+++ b/charts/coturn/templates/secret-ca-certificate.yaml
@@ -1,0 +1,17 @@
+{{- if and .Values.ca.enabled .Values.ca.cert -}}
+
+{{- if .Values.ca.secretRef -}}
+{{- fail "ca.cert and ca.secretRef are mutually exclusive - use one or the other, not both" -}}
+{{- end -}}
+
+apiVersion: v1
+kind: Secret
+metadata:
+  name: coturn-ca-certificate
+  labels:
+    {{- include "coturn.labels" . | nindent 4 }}
+type: Opaque
+data:
+  ca-certificates.crt: {{ .Values.ca.cert | b64enc }}
+
+{{- end -}}

--- a/charts/coturn/templates/statefulset.yaml
+++ b/charts/coturn/templates/statefulset.yaml
@@ -28,6 +28,10 @@ spec:
         {{- end }}
         checksum/configmap-coturn: {{ include (print .Template.BasePath "/configmap-coturn-conf-template.yaml") . | sha256sum }}
         checksum/secret: {{ include (print .Template.BasePath "/secret.yaml") . | sha256sum }}
+        {{- if and .Values.ca.enabled .Values.ca.cert }}
+        checksum/secret-ca: {{ include (print .Template.BasePath "/secret-ca-certificate.yaml") . | sha256sum }}
+        {{- end }}
+        checksum/ca-config: {{ printf "%v-%v-%v" .Values.ca.enabled .Values.ca.secretRef .Values.ca.secretKey | sha256sum }}
         {{- with .Values.podAnnotations }}
         {{- toYaml . | nindent 8 }}
         {{- end }}

--- a/charts/coturn/templates/statefulset.yaml
+++ b/charts/coturn/templates/statefulset.yaml
@@ -68,6 +68,11 @@ spec:
           secret:
             secretName: coturn-dtls-certificate
         {{- end }}
+        {{- if and .Values.ca.enabled .Values.ca.secretRef }}
+        - name: secrets-ca
+          secret:
+            secretName: {{ .Values.ca.secretRef }}
+        {{- end }}
         {{- if .Values.ratelimit.allowlist }}
         - name: allowlist-volume
           configMap:
@@ -158,6 +163,11 @@ spec:
           {{- if .Values.federate.dtls.enabled }}
             - name: coturn-dtls-certificate
               mountPath: /coturn-dtls-certificate/
+              readOnly: true
+          {{- end }}
+          {{- if and .Values.ca.enabled .Values.ca.secretRef }}
+            - name: secrets-ca
+              mountPath: /secrets-ca/
               readOnly: true
           {{- end }}
           {{- if .Values.ratelimit.allowlist }}

--- a/charts/coturn/templates/statefulset.yaml
+++ b/charts/coturn/templates/statefulset.yaml
@@ -68,10 +68,10 @@ spec:
           secret:
             secretName: coturn-dtls-certificate
         {{- end }}
-        {{- if and .Values.ca.enabled .Values.ca.secretRef }}
+        {{- if and .Values.ca.enabled (or .Values.ca.secretRef .Values.ca.cert) }}
         - name: secrets-ca
           secret:
-            secretName: {{ .Values.ca.secretRef }}
+            secretName: {{ .Values.ca.secretRef | default "coturn-ca-certificate" }}
         {{- end }}
         {{- if .Values.ratelimit.allowlist }}
         - name: allowlist-volume
@@ -165,7 +165,7 @@ spec:
               mountPath: /coturn-dtls-certificate/
               readOnly: true
           {{- end }}
-          {{- if and .Values.ca.enabled .Values.ca.secretRef }}
+          {{- if and .Values.ca.enabled (or .Values.ca.secretRef .Values.ca.cert) }}
             - name: secrets-ca
               mountPath: /secrets-ca/
               readOnly: true

--- a/charts/coturn/values.yaml
+++ b/charts/coturn/values.yaml
@@ -62,11 +62,11 @@ tls:
 # Controls certificate authority validation for coturn
 ca:
   # When disabled: Uses system CA bundle at /etc/ssl/certs/ca-certificates.crt (default behavior)
-  # When enabled with secretRef: Mounts custom CA bundle from a Kubernetes Secret
-  # When enabled without secretRef: Disables CA validation entirely (not recommended for production)
+  # When enabled with secretRef OR cert: Uses custom CA bundle
+  # When enabled without secretRef or cert: Disables CA validation entirely (not recommended for production)
   enabled: false
 
-  # Reference to a Kubernetes Secret containing the CA bundle
+  # Option 1: Reference to an existing Kubernetes Secret containing the CA bundle
   # The secret must contain a key (default: ca-certificates.crt) with the CA bundle in PEM format
   #
   # Example: Create a secret with your CA bundle:
@@ -80,6 +80,16 @@ ca:
   # The key within the secret that contains the CA bundle (default: ca-certificates.crt)
   # Only used when secretRef is set
   secretKey: ca-certificates.crt
+
+  # Option 2: Inline CA certificate bundle (PEM format)
+  # Mutually exclusive with secretRef - use one or the other, not both
+  #
+  # Example:
+  #   cert: |
+  #     -----BEGIN CERTIFICATE-----
+  #     MIIDXTCCAkWgAwIBAgIJAKJ...
+  #     -----END CERTIFICATE-----
+  cert:
 
 config:
   verboseLogging: false

--- a/charts/coturn/values.yaml
+++ b/charts/coturn/values.yaml
@@ -58,6 +58,29 @@ tls:
     pullPolicy: IfNotPresent
     tag: 72c3c8434660bd157d42012b0bcd67f338fc5c7a
 
+# CA certificate bundle configuration
+# Controls certificate authority validation for coturn
+ca:
+  # When disabled: Uses system CA bundle at /etc/ssl/certs/ca-certificates.crt (default behavior)
+  # When enabled with secretRef: Mounts custom CA bundle from a Kubernetes Secret
+  # When enabled without secretRef: Disables CA validation entirely (not recommended for production)
+  enabled: false
+
+  # Reference to a Kubernetes Secret containing the CA bundle
+  # The secret must contain a key (default: ca-certificates.crt) with the CA bundle in PEM format
+  #
+  # Example: Create a secret with your CA bundle:
+  #   kubectl create secret generic my-ca-bundle --from-file=ca-certificates.crt=/path/to/bundle.pem
+  #
+  # Then reference it here:
+  #   secretRef: my-ca-bundle
+  #   secretKey: ca-certificates.crt
+  secretRef:
+
+  # The key within the secret that contains the CA bundle (default: ca-certificates.crt)
+  # Only used when secretRef is set
+  secretKey: ca-certificates.crt
+
 config:
   verboseLogging: false
 


### PR DESCRIPTION
## Summary

Makes the CA certificate bundle configurable in the coturn Helm chart while maintaining full backward compatibility. Users can now:
- Use custom CA bundles from Kubernetes Secrets
- Continue using the system CA bundle (default)
- Disable CA validation (for testing environments)

## Changes

### 1. New `ca` Configuration Section (values.yaml)
Added a new top-level configuration section following the existing pattern used for `tls` and `federate` sections:

```yaml
ca:
  enabled: false          # Default: uses system CA bundle
  secretRef: null         # Optional: reference to Kubernetes Secret
  secretKey: ca-certificates.crt  # Key within the secret
```

### 2. Conditional CA-file Logic (configmap template)
Replaced the hardcoded CA-file path with conditional logic that supports three modes:
- **Default** (`ca.enabled: false`): Uses `/etc/ssl/certs/ca-certificates.crt`
- **Custom CA** (`ca.enabled: true` + `secretRef`): Mounts from Secret at `/secrets-ca/`
- **Disabled** (`ca.enabled: true`, no `secretRef`): Omits CA-file line entirely

### 3. Volume and VolumeMount (statefulset)
Added conditional volume and volumeMount for custom CA secrets:
- Only created when both `ca.enabled: true` AND `ca.secretRef` is defined
- Follows existing pattern: `readOnly: true`, consistent naming (`secrets-ca`)
- Mount path `/secrets-ca/` matches other secret mounts

## Configuration Examples

### Example 1: Default (No Changes Required)
```yaml
# Uses system CA bundle - backward compatible
# No configuration needed, or explicitly:
ca:
  enabled: false
```

### Example 2: Custom CA Bundle
```yaml
# First create the secret:
# kubectl create secret generic my-ca-bundle \
#   --from-file=ca-certificates.crt=/path/to/bundle.pem

ca:
  enabled: true
  secretRef: my-ca-bundle
  secretKey: ca-certificates.crt
```

### Example 3: Disable Validation (Testing)
```yaml
ca:
  enabled: true
  secretRef: null
```

## Testing Results

All test cases passed successfully using `helm template`:

✅ **Test 1: Default Behavior**
- Configuration: `ca.enabled: false` (or omitted)
- Result: `CA-file=/etc/ssl/certs/ca-certificates.crt`
- No additional volumes created

✅ **Test 2: Custom CA from Secret**
- Configuration: Custom CA with secretRef
- Result: Volume and volumeMount created correctly
- CA-file points to `/secrets-ca/ca-certificates.crt`

✅ **Test 3: Disabled CA Validation**
- Configuration: `ca.enabled: true`, no secretRef
- Result: No CA-file line in config (validation disabled)
- No volumes created

✅ **Test 4: Custom SecretKey**
- Configuration: Custom secretKey name
- Result: Correctly uses custom key in CA-file path

## Backward Compatibility

✅ **No Breaking Changes**
- Default behavior unchanged (system CA bundle)
- Existing deployments continue to work without modification
- New configuration is opt-in only

## Related

Closes: WPB-21388