### PR TITLE
feat: add DDoS reflection amplification attack mitigations

### DIFF
--- a/charts/coturn/templates/configmap-coturn-conf-template.yaml
+++ b/charts/coturn/templates/configmap-coturn-conf-template.yaml
@@ -49,6 +49,8 @@ data:
     no-stun-backward-compatibility
     secure-stun
     no-rfc5780
+    no-software-attribute
+    response-origin-only-with-rfc5780
 
     ## prometheus metrics
     prometheus-ip={{ default "__COTURN_POD_IP__" .Values.coturnPrometheusIP }}


### PR DESCRIPTION
## Summary
- Add `no-software-attribute` configuration flag to prevent disclosure of software version information in STUN responses
- Add `response-origin-only-with-rfc5780` configuration flag to restrict STUN response-origin attribute usage

These configurations harden coturn against DDoS reflection amplification attacks by:
1. Reducing the attack surface through limited information disclosure
2. Restricting response attributes that can be exploited in reflection attacks

## Test plan
- [ ] Deploy the updated Helm chart to a test environment
- [ ] Verify coturn starts successfully with the new configuration
- [ ] Validate that STUN responses do not include software version information
- [ ] Confirm that response-origin attribute behavior is restricted as expected
- [ ] Run existing integration tests to ensure no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)