### PR TITLE
WPB-23565: replace Bitnami image with Docker Hardened Image

### DIFF
--- a/charts/coturn/templates/service-account.yaml
+++ b/charts/coturn/templates/service-account.yaml
@@ -8,6 +8,10 @@ metadata:
     chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
+  {{- with .Values.imagePullSecrets }}
+  imagePullSecrets:
+  {{- toYaml . | indent 2 }}
+  {{- end }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole

--- a/charts/coturn/templates/statefulset.yaml
+++ b/charts/coturn/templates/statefulset.yaml
@@ -84,7 +84,10 @@ spec:
         {{- end }}
       initContainers:
         - name: get-external-ip
-          image: bitnamilegacy/kubectl:1.29.11
+          {{- with .Values.externalIpHelper.image }}
+          image: {{ .repository }}:{{ .tag }}
+          imagePullPolicy: {{ .pullPolicy }}
+          {{- end }}
           resources:
             {{- toYaml .Values.initResources | nindent 12 }}
           volumeMounts:
@@ -96,7 +99,7 @@ spec:
                 fieldRef:
                   fieldPath: spec.nodeName
           command:
-            - /bin/sh
+            - /bin/bash
             - -c
             - |
               set -e

--- a/charts/coturn/values.yaml
+++ b/charts/coturn/values.yaml
@@ -10,6 +10,19 @@ image:
   # overwrite the tag here, otherwise `appVersion` of the chart will be used
   tag: ""
 
+# If your cluster requires image pull secrets to pull the coturn image, add them here. This should be the name of a Kubernetes Secret of type `kubernetes.io/dockerconfigjson` that contains the necessary credentials to pull the image from the registry.
+# Format: [{ name: "my-registry-secret" }, { name: "another-registry-secret" }]
+imagePullSecrets: []
+
+externalIpHelper:
+  # The image used for the initContainer that determines the external IP address of the node.
+  # This is a very small image that just contains kubectl, and is only used during startup.
+  # We chose the `compat` flavor of the image since we need a shell to run the command that determines the external IP address, and the `compat` image includes a shell.
+  image:
+    repository: dhi.io/kubectl
+    pullPolicy: IfNotPresent
+    tag: 1.35-compat
+
 # If you have multiple deployments of coturn running in one cluster, it is
 # important that they run on disjoint sets of nodes, you can use nodeSelector to enforce this
 nodeSelector: {}
@@ -49,7 +62,7 @@ coturnTurnExternalIP: null
 tls:
   enabled: false
   # compliant with BSI TR-02102-2
-  ciphers: 'ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:TLS_AES_128_GCM_SHA256:TLS_AES_256_GCM_SHA384'
+  ciphers: "ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:TLS_AES_128_GCM_SHA256:TLS_AES_256_GCM_SHA384"
   secretRef:
   reloaderImage:
     # container image containing https://github.com/Pluies/config-reloader-sidecar
@@ -102,40 +115,40 @@ federate:
     enabled: false
 
     tls:
-  #   Example:
-  #
-  #   tls:
-  #     key: "-----BEGIN EC PRIVATE KEY----- ..." # (ascii blob) private key
-  #     crt: "-----BEGIN CERTIFICATE----- ..." # (ascii blob) certificate
-  #     privateKeyPassword: "XXX" # optional, used when the key is password protected
-  #
-  #   OR (mutually exclusive)
-  #
-  #   tls:
-  #      issuerRef:
-  #        name: letsencrypt-http01
-  #
-  #        # We can reference ClusterIssuers by changing the kind here.
-  #        # The default value is Issuer (i.e. a locally namespaced Issuer)
-  #        # kind: Issuer
-  #        kind: Issuer
-  #
-  #        # This is optional since cert-manager will default to this value however
-  #        # if you are using an external issuer, change this to that issuer group.
-  #        group: cert-manager.io
-  #
-  #      # optional labels to attach to the cert-manager Certificate
-  #      certificate:
-  #        labels: ..
+    #   Example:
+    #
+    #   tls:
+    #     key: "-----BEGIN EC PRIVATE KEY----- ..." # (ascii blob) private key
+    #     crt: "-----BEGIN CERTIFICATE----- ..." # (ascii blob) certificate
+    #     privateKeyPassword: "XXX" # optional, used when the key is password protected
+    #
+    #   OR (mutually exclusive)
+    #
+    #   tls:
+    #      issuerRef:
+    #        name: letsencrypt-http01
+    #
+    #        # We can reference ClusterIssuers by changing the kind here.
+    #        # The default value is Issuer (i.e. a locally namespaced Issuer)
+    #        # kind: Issuer
+    #        kind: Issuer
+    #
+    #        # This is optional since cert-manager will default to this value however
+    #        # if you are using an external issuer, change this to that issuer group.
+    #        group: cert-manager.io
+    #
+    #      # optional labels to attach to the cert-manager Certificate
+    #      certificate:
+    #        labels: ..
 
-  # # list of host/ip/cert common names / subject alt names, and optional issuer
-  # # names to accept DTLS connections from. There can be multiple entries.
-  # remoteWhitelist:
-  #   - host: wire.example
-  #     issuer: Issuer Common Name
-  #   - host: another.wire.example
-  #     issuer: "DigiCert SHA2 Extended Validation Server CA"
-  #   - host: another-host-without-issuer.wire.example
+    # # list of host/ip/cert common names / subject alt names, and optional issuer
+    # # names to accept DTLS connections from. There can be multiple entries.
+    # remoteWhitelist:
+    #   - host: wire.example
+    #     issuer: Issuer Common Name
+    #   - host: another.wire.example
+    #     issuer: "DigiCert SHA2 Extended Validation Server CA"
+    #   - host: another-host-without-issuer.wire.example
     remoteWhitelist: []
 
 ratelimit:
@@ -145,7 +158,7 @@ ratelimit:
   # # Set the time window duration in seconds for rate limiting 401 Unauthorized responses. Defaults is 120.
   # window: 120
   # # Define the IPs allowed to bypass the 401 rate-limiting
-  # allowlist: 
+  # allowlist:
   #   - "192.168.1.1"
   #   - "192.168.1.2"
 


### PR DESCRIPTION
# What's new in this PR?

### Issues

Since the acquisition of Bitnami, they have been discontinuing their free service of providing hardened images, in favour of a paid enterprise service.

### Solutions

We have chosen Docker Hardened Images as a replacement, which offers a free tier.
To facilitate this, the Helm chart was extended to allow specifying the repo and tag for the Kubectl image, as well as an optional `imagePullSecret` value to be used in creation of the `ServiceAccount` resource.

### Dependencies

Pulling images from dhi.io requires logging in to the registry:
* using `docker login`
* using an [image pull secret](https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/) and passing the name to the `imagePullSecret` value.


### Testing

The code changes in this PR have only been manually tested.
related to WPB-23565 and WPB-18320
