### PR TITLE
WPB-18320: make get-external-ip image configurable and upgrade kubectl

### DIFF
--- a/charts/coturn/templates/statefulset.yaml
+++ b/charts/coturn/templates/statefulset.yaml
@@ -84,7 +84,10 @@ spec:
         {{- end }}
       initContainers:
         - name: get-external-ip
-          image: bitnamilegacy/kubectl:1.29.11
+          {{- with .Values.externalIpHelper.image }}
+          image: {{ .repository }}:{{ .tag }}
+          imagePullPolicy: {{ .pullPolicy }}
+          {{- end }}
           resources:
             {{- toYaml .Values.initResources | nindent 12 }}
           volumeMounts:
@@ -95,8 +98,8 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: spec.nodeName
-          command:
-            - /bin/sh
+          command: ['/bin/sh']
+          args:
             - -c
             - |
               set -e
@@ -126,6 +129,10 @@ spec:
                 echo "Error: No external IP found after $max_tries attempts." >&2
                 exit 1
               fi
+          securityContext:
+            allowPrivilegeEscalation: false
+            runAsRoot: false
+            runAsUser: 65534 # non-root user in alpine
       containers:
         - name: {{ .Chart.Name }}
           image: "{{ .Values.image.repository}}:{{ .Values.image.tag | default .Chart.AppVersion }}"

--- a/charts/coturn/values.yaml
+++ b/charts/coturn/values.yaml
@@ -111,40 +111,40 @@ federate:
     enabled: false
 
     tls:
-  #   Example:
-  #
-  #   tls:
-  #     key: "-----BEGIN EC PRIVATE KEY----- ..." # (ascii blob) private key
-  #     crt: "-----BEGIN CERTIFICATE----- ..." # (ascii blob) certificate
-  #     privateKeyPassword: "XXX" # optional, used when the key is password protected
-  #
-  #   OR (mutually exclusive)
-  #
-  #   tls:
-  #      issuerRef:
-  #        name: letsencrypt-http01
-  #
-  #        # We can reference ClusterIssuers by changing the kind here.
-  #        # The default value is Issuer (i.e. a locally namespaced Issuer)
-  #        # kind: Issuer
-  #        kind: Issuer
-  #
-  #        # This is optional since cert-manager will default to this value however
-  #        # if you are using an external issuer, change this to that issuer group.
-  #        group: cert-manager.io
-  #
-  #      # optional labels to attach to the cert-manager Certificate
-  #      certificate:
-  #        labels: ..
+    #   Example:
+    #
+    #   tls:
+    #     key: "-----BEGIN EC PRIVATE KEY----- ..." # (ascii blob) private key
+    #     crt: "-----BEGIN CERTIFICATE----- ..." # (ascii blob) certificate
+    #     privateKeyPassword: "XXX" # optional, used when the key is password protected
+    #
+    #   OR (mutually exclusive)
+    #
+    #   tls:
+    #      issuerRef:
+    #        name: letsencrypt-http01
+    #
+    #        # We can reference ClusterIssuers by changing the kind here.
+    #        # The default value is Issuer (i.e. a locally namespaced Issuer)
+    #        # kind: Issuer
+    #        kind: Issuer
+    #
+    #        # This is optional since cert-manager will default to this value however
+    #        # if you are using an external issuer, change this to that issuer group.
+    #        group: cert-manager.io
+    #
+    #      # optional labels to attach to the cert-manager Certificate
+    #      certificate:
+    #        labels: ..
 
-  # # list of host/ip/cert common names / subject alt names, and optional issuer
-  # # names to accept DTLS connections from. There can be multiple entries.
-  # remoteWhitelist:
-  #   - host: wire.example
-  #     issuer: Issuer Common Name
-  #   - host: another.wire.example
-  #     issuer: "DigiCert SHA2 Extended Validation Server CA"
-  #   - host: another-host-without-issuer.wire.example
+    # # list of host/ip/cert common names / subject alt names, and optional issuer
+    # # names to accept DTLS connections from. There can be multiple entries.
+    # remoteWhitelist:
+    #   - host: wire.example
+    #     issuer: Issuer Common Name
+    #   - host: another.wire.example
+    #     issuer: "DigiCert SHA2 Extended Validation Server CA"
+    #   - host: another-host-without-issuer.wire.example
     remoteWhitelist: []
 
 ratelimit:
@@ -154,7 +154,7 @@ ratelimit:
   # # Set the time window duration in seconds for rate limiting 401 Unauthorized responses. Defaults is 120.
   # window: 120
   # # Define the IPs allowed to bypass the 401 rate-limiting
-  # allowlist: 
+  # allowlist:
   #   - "192.168.1.1"
   #   - "192.168.1.2"
 

--- a/charts/coturn/values.yaml
+++ b/charts/coturn/values.yaml
@@ -10,6 +10,15 @@ image:
   # overwrite the tag here, otherwise `appVersion` of the chart will be used
   tag: ""
 
+externalIpHelper:
+  # The image used for the initContainer that determines the external IP address of the node.
+  # This is a very small image that just contains kubectl, and is only used during startup.
+  # We chose the `compat` flavor of the image since we need a shell to run the command that determines the external IP address, and the `compat` image includes a shell.
+  image:
+    repository: docker.io/alpine/kubectl
+    pullPolicy: IfNotPresent
+    tag: 1.35.1
+
 # If you have multiple deployments of coturn running in one cluster, it is
 # important that they run on disjoint sets of nodes, you can use nodeSelector to enforce this
 nodeSelector: {}
@@ -49,7 +58,7 @@ coturnTurnExternalIP: null
 tls:
   enabled: false
   # compliant with BSI TR-02102-2
-  ciphers: 'ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:TLS_AES_128_GCM_SHA256:TLS_AES_256_GCM_SHA384'
+  ciphers: "ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:TLS_AES_128_GCM_SHA256:TLS_AES_256_GCM_SHA384"
   secretRef:
   reloaderImage:
     # container image containing https://github.com/Pluies/config-reloader-sidecar


### PR DESCRIPTION
# What's new in this PR?

### Issues

* the `bitnami/kubectl` image used in the `get-external-ip` initContainer is EOL and has many CVEs
* also, the repo and tag are hard-coded

### Solutions

* `externalIpHelper.image` is added to the Helm Chart's values to make the image+tag easily configurable
* moved from `bitnami/kubectl` to `alpine/kubectl` which has a similarly small footprint
* updated to support recent Kubernetes versions

### Testing


#### How to Test

The change has been manually tested in a QA environment by rendering the chart + applying the Statefulset. The external IP of the node running the pod was properly written to the expected path.


### Notes
Related to WPB-18320
closes #41 