### PR TITLE
use realistic coturn memory limits

### DIFF
--- a/charts/coturn/values.yaml
+++ b/charts/coturn/values.yaml
@@ -23,13 +23,11 @@ externalIpHelper:
 # important that they run on disjoint sets of nodes, you can use nodeSelector to enforce this
 nodeSelector: {}
 
-# Limiting memory usage to ~90% of the available memory on a 8Gb node which is used for coturn pods by default.
-# This is to prevent the pod from being OOM kill
 resources:
   requests:
-    memory: 512Mi
+    memory: 256Mi
   limits:
-    memory: 6.5Gi
+    memory: 512Mi
 
 initResources:
   requests:

--- a/charts/coturn/values.yaml
+++ b/charts/coturn/values.yaml
@@ -25,9 +25,8 @@ nodeSelector: {}
 
 resources:
   requests:
+    cpu: 500m
     memory: 256Mi
-  limits:
-    memory: 512Mi
 
 initResources:
   requests:


### PR DESCRIPTION
The existing coturn resource defaults no longer reflect its observed production footprint and can lead to significantly oversized coturn nodes (previous memory limits where necessary because of memory leaks that have since been fixed).

  At approximately max. 650 relayed allocations per server, pod-level production metrics showed:

  - Memory p99: ~152 MiB
  - Memory peak: ~174 MiB
  - CPU p99: ~393m

  Based on these observations, this PR:

  - sets the memory request to `256Mi`
  - adds a `500m` CPU request
  - removes the default memory limit
  - leaves the init-container resources unchanged

  Coturn runs one pod per node due to `hostNetwork`, and the appropriate memory ceiling depends on the node and expected relay workload. Operators can still configure `resources.limits` explicitly when required. No CPU limit
  is set, allowing coturn to burst when necessary.