### PR TITLE
Fix invalid securityContext field on get-external-ip initContainer

### DIFF
--- a/charts/coturn/templates/statefulset.yaml
+++ b/charts/coturn/templates/statefulset.yaml
@@ -131,7 +131,7 @@ spec:
               fi
           securityContext:
             allowPrivilegeEscalation: false
-            runAsRoot: false
+            runAsNonRoot: true
             runAsUser: 65534 # non-root user in alpine
       containers:
         - name: {{ .Chart.Name }}


### PR DESCRIPTION
## Problem

Upgrading the chart from `wireapp/4.6.2-federation-wireapp.47` to `.52` fails during sync (Argo CD) with:

```
failed to create typed patch object (wire/coturn; apps/v1, Kind=StatefulSet):
.spec.template.spec.initContainers[name="get-external-ip"].securityContext.runAsRoot: field not declared in schema
```

## Root cause

Commit `60f99898` (WPB-18320) added a `securityContext` to the `get-external-ip` initContainer using the field `runAsRoot: false`. **`runAsRoot` is not a field in the Kubernetes `SecurityContext` schema** — the correct field is `runAsNonRoot`.

Client-side apply silently tolerates unknown fields, which is why it wasn't caught. Server-side apply (used by Argo CD) builds a *typed* patch validated against the cluster OpenAPI schema and rejects the unknown field.

## Fix

Replace `runAsRoot: false` with `runAsNonRoot: true`, matching the original intent of running as the non-root user `65534`.

```yaml
securityContext:
  allowPrivilegeEscalation: false
  runAsNonRoot: true
  runAsUser: 65534 # non-root user in alpine
```

Verified with `helm template` / `helm lint`.
