### PR TITLE
feat: pin the port 9191 to SNAT

### DIFF
--- a/charts/coturn/templates/statefulset.yaml
+++ b/charts/coturn/templates/statefulset.yaml
@@ -133,6 +133,32 @@ spec:
             allowPrivilegeEscalation: false
             runAsNonRoot: true
             runAsUser: 65534 # non-root user in alpine
+        {{- if .Values.federate.enabled }}
+        # Pin the federation source port on node egress so the node SNAT
+        # (e.g. AWS VPC CNI --random-fully) does not randomize it and break the
+        # remote peer's return DTLS handshake. Runs in the host
+        # netns because the pod is hostNetwork. See WPB-26112.
+        - name: pin-federation-sport
+          image: alpine:3
+          command: ['/bin/sh', '-c']
+          args:
+            - |
+              apk add --no-cache iptables conntrack-tools
+              P={{ .Values.federate.port }}
+              iptables-nft -t nat -C POSTROUTING -p udp --sport $P -j SNAT --to-source "$NODE_IP:$P" 2>/dev/null || {
+                iptables-nft -t nat -I POSTROUTING 1 -p udp --sport $P -j SNAT --to-source "$NODE_IP:$P"
+                conntrack -D -p udp --orig-port-src $P || true
+              }
+          env:
+            - name: NODE_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.hostIP
+          securityContext:
+            privileged: true
+            capabilities:
+              add: ["NET_ADMIN"]
+        {{- end }}
       containers:
         - name: {{ .Chart.Name }}
           image: "{{ .Values.image.repository}}:{{ .Values.image.tag | default .Chart.AppVersion }}"

--- a/charts/coturn/templates/statefulset.yaml
+++ b/charts/coturn/templates/statefulset.yaml
@@ -139,17 +139,36 @@ spec:
         # remote peer's return DTLS handshake. Runs in the host
         # netns because the pod is hostNetwork. See WPB-26112.
         - name: pin-federation-sport
-          image: "{{ .Values.externalIpHelper.image.repository }}:{{ .Values.externalIpHelper.image.tag }}"
-          imagePullPolicy: {{ .Values.externalIpHelper.image.pullPolicy }}
+          {{- with .Values.federate.snat.image }}
+          image: {{ .repository }}:{{ .tag }}
+          imagePullPolicy: {{ .pullPolicy }}
+          {{- end }}
+          resources:
+            {{- toYaml .Values.initResources | nindent 12 }}
           command: ['/bin/sh', '-c']
           args:
             - |
-              apk add --no-cache iptables conntrack-tools
+              set -eu
               P={{ .Values.federate.port }}
-              iptables-nft -t nat -C POSTROUTING -p udp --sport $P -j SNAT --to-source "$NODE_IP:$P" 2>/dev/null || {
-                iptables-nft -t nat -I POSTROUTING 1 -p udp --sport $P -j SNAT --to-source "$NODE_IP:$P"
-                conntrack -D -p udp --orig-port-src $P || true
-              }
+              RULE="-p udp --sport $P -j SNAT --to-source $NODE_IP:$P"
+              log() { echo "[pin-federation-sport] $*"; }
+
+              log "pinning UDP source port $P to $NODE_IP:$P in nat/POSTROUTING"
+              if iptables-nft -t nat -C POSTROUTING $RULE 2>/dev/null; then
+                log "rule already present, leaving it in place: $RULE"
+              else
+                log "rule missing, inserting at POSTROUTING position 1: $RULE"
+                iptables-nft -t nat -I POSTROUTING 1 $RULE
+                log "flushing stale conntrack entries for udp src port $P"
+                if conntrack -D -p udp --orig-port-src "$P" 2>/dev/null; then
+                  log "conntrack entries flushed"
+                else
+                  log "no matching conntrack entries (nothing to flush)"
+                fi
+              fi
+
+              log "resulting nat/POSTROUTING chain:"
+              iptables-nft -t nat -L POSTROUTING -n -v --line-numbers
           env:
             - name: NODE_IP
               valueFrom:

--- a/charts/coturn/templates/statefulset.yaml
+++ b/charts/coturn/templates/statefulset.yaml
@@ -133,13 +133,14 @@ spec:
             allowPrivilegeEscalation: false
             runAsNonRoot: true
             runAsUser: 65534 # non-root user in alpine
-        {{- if .Values.federate.enabled }}
+        {{- if and .Values.federate.enabled .Values.federate.snat.enabled }}
         # Pin the federation source port on node egress so the node SNAT
         # (e.g. AWS VPC CNI --random-fully) does not randomize it and break the
         # remote peer's return DTLS handshake. Runs in the host
         # netns because the pod is hostNetwork. See WPB-26112.
         - name: pin-federation-sport
-          image: alpine:3
+          image: "{{ .Values.externalIpHelper.image.repository }}:{{ .Values.externalIpHelper.image.tag }}"
+          imagePullPolicy: {{ .Values.externalIpHelper.image.pullPolicy }}
           command: ['/bin/sh', '-c']
           args:
             - |

--- a/charts/coturn/values.yaml
+++ b/charts/coturn/values.yaml
@@ -107,6 +107,11 @@ federate:
   enabled: false
   port: 9191
 
+  snat:
+    # Preserve the federation source port through node-level SNAT. This requires
+    # a privileged init container and should only be enabled where needed.
+    enabled: false
+
   dtls:
     enabled: false
 

--- a/charts/coturn/values.yaml
+++ b/charts/coturn/values.yaml
@@ -111,6 +111,11 @@ federate:
     # Preserve the federation source port through node-level SNAT. This requires
     # a privileged init container and should only be enabled where needed.
     enabled: false
+    # Must ship iptables-nft and conntrack (no runtime install, works air-gapped).
+    image:
+      repository: registry.k8s.io/build-image/debian-iptables
+      pullPolicy: IfNotPresent
+      tag: bookworm-v1.0.0
 
   dtls:
     enabled: false


### PR DESCRIPTION
Ticket: https://wearezeta.atlassian.net/browse/WPB-26951

---
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

### Issues
Coturn servers communicate over UDP port **9191**. Kubernetes node NAT rewrites the source port, so replies no longer match the connection. The secure handshake fails, causing **one-way audio**.

### Solutions
Add an SNAT rule that preserves source port **9191**.

### Testing
Run on a coturn node:
```bash
iptables-nft -t nat -S POSTROUTING | grep 9191
```
Expected:
```bash
-A POSTROUTING -p udp --sport 9191 -j SNAT --to-source 10.20.22.106:9191
```
The rule must appear **before** `AWS-SNAT-CHAIN-0`.

# Verify during a federated test call

```bash
conntrack -L -p udp --orig-port-src 9191
```
Good:
```text
sport=9191 dport=9191 ... sport=9191 dport=9191
```
Bad: any random rewritten port, such as `sport=54123`.
The actual pass condition is **audio working in both directions**.

### Notes
The fix must exist on both coturn nodes handling the call.