### PR TITLE
Clarify federation SNAT mitigation and fix nil-pointer errors with issuer-only DTLS configuration

### DIFF
--- a/charts/coturn/Chart.yaml
+++ b/charts/coturn/Chart.yaml
@@ -6,7 +6,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.0.45
+version: 0.0.46
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/coturn/values.yaml
+++ b/charts/coturn/values.yaml
@@ -105,8 +105,13 @@ federate:
   port: 9191
 
   snat:
-    # Preserve the federation source port through node-level SNAT. This requires
-    # a privileged init container and should only be enabled where needed.
+    # Targeted mitigation for a proven node-level conntrack/SNAT clash on the
+    # federation path. Do not enable merely because coturn runs on Kubernetes
+    # or behind NAT. Enable only after packet capture or conntrack evidence
+    # shows that node SNAT rewrites the source port and fragments the peer's
+    # DTLS ClientHello into multiple apparent source ports. Stable translated
+    # source ports do not need this option. This adds a privileged init
+    # container with NET_ADMIN and pins sport 9191 to the node IP.
     enabled: false
     # Must ship iptables-nft and conntrack (no runtime install, works air-gapped).
     image:
@@ -118,6 +123,11 @@ federate:
     enabled: false
 
     tls:
+      # Keep the optional certificate map defined so issuerRef-only values
+      # render without a nil lookup in the chart template.
+      certificate:
+        dnsNames: []
+        labels: {}
     #   Example:
     #
     #   tls:


### PR DESCRIPTION
### Summary
- Clarify that federate.snat.enabled is a targeted conntrack-clash mitigation, not a general Kubernetes or NAT requirement.
- Define the optional certificate map to prevent nil-pointer errors with issuer-only DTLS configuration.
- Bump the chart version to 0.0.46.

### Validation
- helm lint charts/coturn
- Rendered the chart with SNAT and DTLS enabled.